### PR TITLE
Configure coverage reporting

### DIFF
--- a/apollo-bom/pom.xml
+++ b/apollo-bom/pom.xml
@@ -11,9 +11,6 @@
     <packaging>pom</packaging>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
         <cucumber.version>1.2.4</cucumber.version>
         <auto-matter.version>0.11.0</auto-matter.version>
     </properties>

--- a/apollo-core/pom.xml
+++ b/apollo-core/pom.xml
@@ -82,20 +82,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.7.4.201502262128</version>
                         <executions>
-                            <execution>
-                                <goals>
-                                    <goal>prepare-agent</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>report</id>
-                                <phase>prepare-package</phase>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                            </execution>
                             <execution>
                                 <id>check</id>
                                 <goals>

--- a/apollo-route/pom.xml
+++ b/apollo-route/pom.xml
@@ -56,20 +56,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.7.4.201502262128</version>
                         <executions>
-                            <execution>
-                                <goals>
-                                    <goal>prepare-agent</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>report</id>
-                                <phase>prepare-package</phase>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                            </execution>
                             <execution>
                                 <id>check</id>
                                 <goals>

--- a/circle.yml
+++ b/circle.yml
@@ -6,11 +6,12 @@ dependencies:
   # since dependency:resolve fails for multi-module builds
   # our best option (that I know of) is to just do a compile
   override:
-    - mvn -Pcoverage -Pmissinglink --fail-never dependency:go-offline compiler:compile || true
+    - mvn -Pcoverage -Pmissinglink --fail-never dependency:go-offline clean compile || true
 
 test:
   override:
     - mvn -Pcoverage -Pmissinglink integration-test
   post:
+    - mvn org.eluder.coveralls:coveralls-maven-plugin:report -Dcoveralls.token=$COVERALLS_TOKEN
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
         <tag>HEAD</tag>
     </scm>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -178,7 +183,15 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.4.201502262128</version>
+                    <version>0.7.5.201505241946</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.eluder.coveralls</groupId>
+                    <artifactId>coveralls-maven-plugin</artifactId>
+                    <version>4.0.0</version>
+                    <configuration>
+                        <repoToken>${coveralls.token}</repoToken>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -193,6 +206,10 @@
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 
@@ -204,6 +221,13 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/AutoValue_*</exclude>
+                                <exclude>**/LoadedConfigBuilder*</exclude>
+                                <exclude>**/MetaInfoBuilder*</exclude>
+                            </excludes>
+                        </configuration>
                         <executions>
                             <execution>
                                 <goals>


### PR DESCRIPTION
I wanted to set up coverage reporting to Coveralls but ran into an issue with jacoco in multi-module projects: https://github.com/trautonen/coveralls-maven-plugin/issues/64

I'm going to explore replacing jacoco with cobertura because of the aggregate report support.
