### PR TITLE
Draft: Contributor guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## HEAD
+
+* Replace me with one change per line
+* Please :)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,0 @@
-# Changelog
-
-## HEAD
-
-* Replace me with one change per line
-* Please :)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,17 +16,15 @@ Ok, so now you can write some code. Have fun!
 
 ### 4. Add tests for your feature. Make the tests pass:
 
-    mvn verify
+    mvn -Pcoverage verify
     
 ### 5. Write documentation
 
 Make sure to document your feature in the relevant places (Javadoc comments, README files, etc).
 
-### 6. Briefly describe your change in the CHANGELOG.md file under HEAD
+### 6. Push to your fork and [submit a pull request][pr].
 
-This makes sure we announce the change in the next release.
-
-### 7. Push to your fork and [submit a pull request][pr].
+Make sure the PR text mentions the motivation and details for your change.
 
 [pr]: https://github.com/spotify/apollo/compare/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+We love pull requests. Here's a quick guide.
+
+### 1. Fork, then clone the repo:
+
+    git clone git@github.com:spotify/apollo.git
+
+### 2. Install dependencies & build:
+
+    mvn package
+
+### 3. Write your feature
+
+Ok, so now you can write some code. Have fun!
+
+### 4. Add tests for your feature. Make the tests pass:
+
+    mvn verify
+    
+### 5. Write documentation
+
+Make sure to document your feature in the relevant places (Javadoc comments, README files, etc).
+
+### 6. Briefly describe your change in the CHANGELOG.md file under HEAD
+
+This makes sure we announce the change in the next release.
+
+### 7. Push to your fork and [submit a pull request][pr].
+
+[pr]: https://github.com/spotify/apollo/compare/
+
+CircleCI will run the test suite and let you know that you've done an awesome job. If CircleCI says A-OK, your work is done for now. At this point you're waiting on us. We like to at least comment on pull requests
+within two business days (and, typically, one business day). We may suggest
+some changes or improvements or alternatives. We promise to respond to all PRs.


### PR DESCRIPTION
In a FOSS project it's important to have some contributor guidelines that can help people join the project. This files is based on the process we have already in the spotify/lingon project, which has worked well. It explains the basic steps to contribute as well as mentioning quality requirements and maintainer response time. 

The guidelines have been copied from the spotify/lingon project where they have worked well. We especially like the CHANGELOG file, which helps us keep track of where bugs were fixed, etc. 

Please take a look at the instructions to make sure they make sense. Also, let's evolve this document as we see fit to adapt it to this project.