### PR TITLE
No example deploys, Include examples as sub modules

### DIFF
--- a/apollo-example/pom.xml
+++ b/apollo-example/pom.xml
@@ -81,6 +81,18 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
+
+            <!-- Do not deploy, this is just an example -->
+            <!-- TODO: Remove or move to one example -->
+            <!-- TODO: set up ci to build and verify this -->
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>2.8.2</version>
+              <configuration>
+                <skip>true</skip>
+              </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/examples/calculator/pom.xml
+++ b/examples/calculator/pom.xml
@@ -103,6 +103,17 @@
                     </archive>
                 </configuration>
             </plugin>
+
+            <!-- Do not deploy, this is just an example -->
+            <!-- TODO: set up ci to build and verify this -->
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-deploy-plugin</artifactId>
+              <version>2.8.2</version>
+              <configuration>
+                <skip>true</skip>
+              </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,13 @@
         <module>modules/slack</module>
         <module>modules/jetty-http-server</module>
         <module>modules/okhttp-client</module>
+
+        <!-- include examples as modules, to get them built and verified -->
+        <!-- NOTE: they configure the maven-deploy-plugin to skip deployment -->
+        <!-- TODO: should separate ci builds be set up for each independent group of artifacts? -->
+        <!-- (api, impl, modules, assemblies, examples, ...) -->
+        <module>apollo-example</module>
+        <module>examples/calculator</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
maven-deploy-plugin skip deploys,
build examples as submodules

this brings back some cumbersomeness when using versions:set or release:prepare, if example versions do not follow the main project version, hence the

```
      <!-- TODO: should separate ci builds be set up for each independent group of artifacts? -->
      <!-- (api, impl, modules, assemblies, examples, ...) -->
```
