### PR TITLE
Move ThreadExceptionHandler and make package private

### DIFF
--- a/apollo-test/src/main/java/com/spotify/apollo/test/experimental/PerformanceFixture.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/experimental/PerformanceFixture.java
@@ -24,7 +24,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import com.spotify.apollo.test.StubClient;
-import com.spotify.apollo.test.ThreadExceptionHandler;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;

--- a/apollo-test/src/main/java/com/spotify/apollo/test/experimental/ThreadExceptionHandler.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/experimental/ThreadExceptionHandler.java
@@ -17,12 +17,12 @@
  * limitations under the License.
  * -/-/-
  */
-package com.spotify.apollo.test;
+package com.spotify.apollo.test.experimental;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ThreadExceptionHandler implements Thread.UncaughtExceptionHandler {
+class ThreadExceptionHandler implements Thread.UncaughtExceptionHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(ThreadExceptionHandler.class);
 


### PR DESCRIPTION
This should not be part of the public api of apollo-test