### PR TITLE
fix MetaDescriptorTest

### DIFF
--- a/apollo-api-impl/src/test/java/com/spotify/apollo/meta/MetaDescriptorTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/meta/MetaDescriptorTest.java
@@ -32,6 +32,6 @@ public class MetaDescriptorTest {
   public void testLoadApolloVersion() throws Exception {
     ClassLoader classLoader = ClassLoader.getSystemClassLoader();
     String version = MetaDescriptor.loadApolloVersion(classLoader);
-    assertTrue(version.startsWith("1.0.0"));
+    assertTrue(version.startsWith("1.0"));
   }
 }


### PR DESCRIPTION
Removing an incorrect version prefix. This is not a great test anyway, I guess, but it's also not a big deal.