### PR TITLE
Add map and flatMap to (A)SyncHandler

### DIFF
--- a/apollo-api-impl/src/main/java/com/spotify/apollo/route/Middlewares.java
+++ b/apollo-api-impl/src/main/java/com/spotify/apollo/route/Middlewares.java
@@ -98,8 +98,7 @@ public final class Middlewares {
    * Returns the default middlewares applied by Apollo to routes supplied by a {@link RouteProvider}.
    */
   public static Middleware<AsyncHandler<?>, AsyncHandler<Response<ByteString>>> apolloDefaults() {
-    return ((Middleware<AsyncHandler<?>, AsyncHandler<Response<ByteString>>>) Middlewares::autoSerialize)
-        .and(Middlewares::httpPayloadSemantics);
+    return serialize(new AutoSerializer()).and(Middlewares::httpPayloadSemantics);
   }
 
   private static Response<ByteString> applyHttpPayloadSemantics(

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/route/MiddlewaresTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/route/MiddlewaresTest.java
@@ -59,9 +59,8 @@ import static org.mockito.Mockito.when;
 
 public class MiddlewaresTest {
 
-  @Mock
   AsyncHandler<Response<ByteString>> delegate;
-  @Mock
+
   AsyncHandler<Object> serializationDelegate;
 
   @Mock
@@ -89,8 +88,8 @@ public class MiddlewaresTest {
     when(requestContext.request()).thenReturn(request);
     when(request.method()).thenReturn("GET");
 
-    when(delegate.invoke(requestContext)).thenReturn(future);
-    when(serializationDelegate.invoke(requestContext)).thenReturn(serializationFuture);
+    delegate = requestContext -> future;
+    serializationDelegate = requestContext -> serializationFuture;
   }
 
   @Test
@@ -189,7 +188,7 @@ public class MiddlewaresTest {
 
     for (StatusType status : invalid) {
       CompletableFuture<Response<ByteString>> future = new CompletableFuture<>();
-      when(delegate.invoke(requestContext)).thenReturn(future);
+      delegate = requestContext -> future;
       future.complete(Response.of(status, ByteString.of((byte) 14, (byte) 19)));
 
       Response<ByteString> result = getResult(Middlewares.httpPayloadSemantics(delegate));

--- a/apollo-api/src/test/java/com/spotify/apollo/route/AsyncHandlerTest.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/route/AsyncHandlerTest.java
@@ -1,0 +1,64 @@
+/*
+ * -\-\-
+ * Spotify Apollo API Interfaces
+ * --
+ * Copyright (C) 2013 - 2015 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.route;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.spotify.apollo.RequestContext;
+
+import org.junit.Test;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class AsyncHandlerTest {
+
+  @Test
+  public void shouldMap() throws Exception {
+    AsyncHandler<String> a = ctx -> completedFuture("hello");
+    AsyncHandler<Integer> b = a.map(String::length);
+
+    int helloLen = b.invoke(TestContext.empty()).toCompletableFuture().get();
+    assertThat(helloLen, is("hello".length()));
+  }
+
+  @Test
+  public void shouldFlatMap() throws Exception {
+    RequestContext context = TestContext.forPathArgs(ImmutableMap.of("foo", "bar", "bar", "baz"));
+
+    AsyncHandler<String> a = ctx -> completedFuture(ctx.pathArgs().get("foo"));
+    AsyncHandler<String> b = a.flatMap(fooVal -> ctx -> completedFuture(ctx.pathArgs().get(fooVal)));
+
+    String baz = b.invoke(context).toCompletableFuture().get();
+    assertThat(baz, is("baz"));
+  }
+
+  @Test
+  public void shouldFlatMapSync() throws Exception {
+    RequestContext context = TestContext.forPathArgs(ImmutableMap.of("foo", "bar", "bar", "baz"));
+
+    AsyncHandler<String> a = ctx -> completedFuture(ctx.pathArgs().get("foo"));
+    AsyncHandler<String> b = a.flatMapSync(fooVal -> ctx -> ctx.pathArgs().get(fooVal));
+
+    String baz = b.invoke(context).toCompletableFuture().get();
+    assertThat(baz, is("baz"));
+  }
+}

--- a/apollo-api/src/test/java/com/spotify/apollo/route/SyncHandlerTest.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/route/SyncHandlerTest.java
@@ -1,0 +1,52 @@
+/*
+ * -\-\-
+ * Spotify Apollo API Interfaces
+ * --
+ * Copyright (C) 2013 - 2015 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.route;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.spotify.apollo.RequestContext;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class SyncHandlerTest {
+
+  @Test
+  public void shouldMap() throws Exception {
+    SyncHandler<String> a = ctx -> "hello";
+    SyncHandler<Integer> b = a.map(String::length);
+
+    int helloLen = b.invoke(TestContext.empty());
+    assertThat(helloLen, is("hello".length()));
+  }
+
+  @Test
+  public void shouldFlatMap() throws Exception {
+    RequestContext context = TestContext.forPathArgs(ImmutableMap.of("foo", "bar", "bar", "baz"));
+
+    SyncHandler<String> a = ctx -> ctx.pathArgs().get("foo");
+    SyncHandler<String> b = a.flatMap(fooVal -> ctx -> ctx.pathArgs().get(fooVal));
+
+    String baz = b.invoke(context);
+    assertThat(baz, is("baz"));
+  }
+}

--- a/apollo-api/src/test/java/com/spotify/apollo/route/TestContext.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/route/TestContext.java
@@ -1,0 +1,46 @@
+/*
+ * -\-\-
+ * Spotify Apollo API Interfaces
+ * --
+ * Copyright (C) 2013 - 2015 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.route;
+
+import com.google.auto.value.AutoValue;
+
+import com.spotify.apollo.Client;
+import com.spotify.apollo.Request;
+import com.spotify.apollo.RequestContext;
+
+import java.util.Collections;
+import java.util.Map;
+
+@AutoValue
+abstract class TestContext implements RequestContext {
+
+  @Override
+  public Client requestScopedClient() {
+    throw new UnsupportedOperationException("no client available");
+  }
+
+  static RequestContext empty() {
+    return new AutoValue_TestContext(Request.forUri("/"), Collections.emptyMap());
+  }
+
+  static RequestContext forPathArgs(Map<String, String> pathArgs) {
+    return new AutoValue_TestContext(Request.forUri("/"), pathArgs);
+  }
+}


### PR DESCRIPTION
While experimenting with writing some middlewares for serialisation/deserialisation, I realised that the handler types are [Reader Monads][1].

Adding these methods helps making middleware implementations much more readable:

```java
<P> Middleware<PayloadResponseHandler<P>, SyncHandler<Response<ByteString>>> forType(Class<P> payloadClass) {
  return innerHandler ->
      deserialize(payloadClass)
          .flatMap(resp -> ctx ->  innerHandler.apply(ctx).apply(resp.payload().get()))
          .map(this::serialize);
}

<P, T> Middleware<PayloadArbitraryHandler<P, T>, SyncHandler<Response<ByteString>>> forType(Class<P> payloadClass) {
  return innerHandler ->
      deserialize(payloadClass)
          .flatMap(resp -> ctx ->  innerHandler.apply(ctx).apply(resp.payload().get()))
          .map(this::ensureResponse)
          .map(this::serialize);
}
```

The signature of `deserialize` is
```java
<P> SyncHandler<Response<P>> deserialize(Class<P> payloadClass)
```

`map` and `flatMap` at least makes it easier to add functions to a request handler chain by not having to explicitly pass along the `RequestContext` in places where it is not needed. But there's a piece missing in being able to map the payload of a response, if present. I will open a separate PR to address that since it's orthogonal to the handler api. see #53 

[1]: http://adit.io/posts/2013-06-10-three-useful-monads.html#the-reader-monad