### PR TITLE
Various improvements to Request

### DIFF
--- a/apollo-api/src/main/java/com/spotify/apollo/Request.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/Request.java
@@ -101,7 +101,7 @@ public interface Request {
   Request withService(String service);
 
   /**
-   * Creates a new {@link Response} based on this, but with an additional header.
+   * Creates a new {@link Request} based on this, but with an additional header.
    *
    * @param name  Header name to add
    * @param value  Header value

--- a/apollo-api/src/main/java/com/spotify/apollo/Request.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/Request.java
@@ -87,6 +87,13 @@ public interface Request {
   Optional<ByteString> payload();
 
   /**
+   * Creates a new {@link Request} based on this, but with a different URI.
+   *
+   * @param uri the new uri
+   */
+  Request withUri(String uri);
+
+  /**
    * Creates a new {@link Request} based on this, but with a different calling service.
    *
    * @param service the new service

--- a/apollo-api/src/main/java/com/spotify/apollo/Request.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/Request.java
@@ -110,6 +110,23 @@ public interface Request {
   Request withHeader(String name, String value);
 
   /**
+   * Creates a new {@link Request} based on this, but with additional headers. If the current
+   * request has a header whose key is also included in the {@code additionalHeaders} map,
+   * then the new request will have the header value defined in the map.
+   *
+   * @param additionalHeaders map of headers to add
+   * @return A request with the added headers
+   */
+  Request withHeaders(Map<String, String> additionalHeaders);
+
+  /**
+   * Creates a new {@link Request} based on this, but with no header information.
+   *
+   * @return A request without headers
+   */
+  Request clearHeaders();
+
+  /**
    * Creates a new {@link Request} based on this, but with a different payload.
    *
    * @param payload the new payload

--- a/apollo-api/src/main/java/com/spotify/apollo/Request.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/Request.java
@@ -31,9 +31,6 @@ import okio.ByteString;
  * Request instances are immutable. However, requests can be built using
  * {@link #forUri(String, String)} methods, and headers and payload can
  * be added using {@link #withHeader(String, String)} and {@link #withPayload(ByteString)}.
- *
- * Note: The deprecated @Request annotation now lives in
- * {@link com.spotify.apollo.route.Request}.
  */
 public interface Request {
   /**

--- a/apollo-api/src/main/java/com/spotify/apollo/RequestValue.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/RequestValue.java
@@ -20,6 +20,7 @@
 package com.spotify.apollo;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -75,9 +76,19 @@ abstract class RequestValue implements Request {
 
   @Override
   public Request withHeader(String name, String value) {
+    return withHeaders(ImmutableMap.of(name, value));
+  }
+
+  @Override
+  public Request withHeaders(Map<String, String> additionalHeaders) {
     Map<String, String> headers = new LinkedHashMap<>(headers());
-    headers.put(name, value);
+    headers.putAll(additionalHeaders);
     return create(method(), uri(), parameters(), headers, service(), payload());
+  }
+
+  @Override
+  public Request clearHeaders() {
+    return create(method(), uri(), parameters(), emptyMap(), service(), payload());
   }
 
   @Override

--- a/apollo-api/src/main/java/com/spotify/apollo/RequestValue.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/RequestValue.java
@@ -58,8 +58,8 @@ abstract class RequestValue implements Request {
       Optional<ByteString> payload) {
     return new AutoValue_RequestValue(
         method, uri,
-        parameters,
-        headers,
+        ImmutableMap.copyOf(parameters),
+        ImmutableMap.copyOf(headers),
         service,
         payload);
   }

--- a/apollo-api/src/main/java/com/spotify/apollo/RequestValue.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/RequestValue.java
@@ -64,6 +64,11 @@ abstract class RequestValue implements Request {
   }
 
   @Override
+  public Request withUri(String uri) {
+    return create(method(), uri, parameters(), headers(), service(), payload());
+  }
+
+  @Override
   public Request withService(String service) {
     return create(method(), uri(), parameters(), headers(), of(service), payload());
   }

--- a/apollo-api/src/test/java/com/spotify/apollo/RequestTest.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/RequestTest.java
@@ -20,9 +20,11 @@
 package com.spotify.apollo;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import org.junit.Test;
 
+import java.util.Map;
 import java.util.Optional;
 
 import okio.ByteString;
@@ -111,5 +113,30 @@ public class RequestTest {
   @Test
   public void shouldAllowModifyingUri() throws Exception {
     assertThat(request("/foo").withUri("/fie").uri(), is("/fie"));
+  }
+
+  @Test
+  public void shouldMergeHeaders() throws Exception {
+    Map<String, String> newHeaders = ImmutableMap.of("newHeader", "value1", "newHeader2", "value2");
+
+    assertThat(requestWithHeader("/foo", "old", "value").withHeaders(newHeaders).headers(),
+               is(ImmutableMap.of("old", "value",
+                                  "newHeader", "value1",
+                                  "newHeader2", "value2")));
+  }
+
+  @Test
+  public void shouldReplaceExistingHeader() throws Exception {
+    Map<String, String> newHeaders = ImmutableMap.of("newHeader", "value1", "old", "value2");
+
+    assertThat(requestWithHeader("/foo", "old", "value").withHeaders(newHeaders).headers(),
+               is(ImmutableMap.of("old", "value2",
+                                  "newHeader", "value1")));
+  }
+
+  @Test
+  public void shouldClearHeaders() throws Exception {
+    assertThat(requestWithHeader("/foo", "old", "value").clearHeaders().headers(),
+               is(ImmutableMap.of()));
   }
 }

--- a/apollo-api/src/test/java/com/spotify/apollo/RequestTest.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/RequestTest.java
@@ -107,4 +107,9 @@ public class RequestTest {
     assertThat(requestWithPayload("/foo", payload).payload(),
                is(Optional.of(payload)));
   }
+
+  @Test
+  public void shouldAllowModifyingUri() throws Exception {
+    assertThat(request("/foo").withUri("/fie").uri(), is("/fie"));
+  }
 }

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpRequest.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpRequest.java
@@ -78,6 +78,12 @@ abstract class HttpRequest implements Request {
       Optional<String> service,
       Map<String, List<String>> parameters,
       Map<String, String> headers) {
-    return new AutoValue_HttpRequest(method, uri, parameters, headers, service, payload);
+    return new AutoValue_HttpRequest(
+        method,
+        uri,
+        ImmutableMap.copyOf(parameters),
+        ImmutableMap.copyOf(headers),
+        service,
+        payload);
   }
 }

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpRequest.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpRequest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 
 import com.spotify.apollo.Request;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,6 +57,18 @@ abstract class HttpRequest implements Request {
   @Override
   public Request withPayload(ByteString payload) {
     return create(method(), uri(), of(payload), service(), parameters(), headers());
+  }
+
+  @Override
+  public Request withHeaders(Map<String, String> additionalHeaders) {
+    Map<String, String> headers = new LinkedHashMap<>(headers());
+    headers.putAll(additionalHeaders);
+    return create(method(), uri(), payload(), service(), parameters(), headers);
+  }
+
+  @Override
+  public Request clearHeaders() {
+    return create(method(), uri(), payload(), service(), parameters(), ImmutableMap.of());
   }
 
   public static Request create(

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpRequest.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpRequest.java
@@ -36,6 +36,11 @@ import static java.util.Optional.of;
 abstract class HttpRequest implements Request {
 
   @Override
+  public Request withUri(String uri) {
+    return create(method(), uri, payload(), service(), parameters(), headers());
+  }
+
+  @Override
   public Request withService(String service) {
     return create(method(), uri(), payload(), of(service), parameters(), headers());
   }

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpRequestTest.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpRequestTest.java
@@ -1,0 +1,65 @@
+/*
+ * -\-\-
+ * Spotify Apollo Jetty HTTP Server Module
+ * --
+ * Copyright (C) 2013 - 2015 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.http.server;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.spotify.apollo.Request;
+
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class HttpRequestTest {
+
+  private Request requestWithHeader(String uri, String header, String value) {
+    return HttpRequest.create("GET", uri, Optional.empty(), Optional.empty(),
+                              ImmutableMap.of(), ImmutableMap.of(header, value));
+  }
+
+  @Test
+  public void shouldMergeHeaders() throws Exception {
+    Map<String, String> newHeaders = ImmutableMap.of("newHeader", "value1", "newHeader2", "value2");
+
+    assertThat(requestWithHeader("/foo", "old", "value").withHeaders(newHeaders).headers(),
+               is(ImmutableMap.of("old", "value",
+                                  "newHeader", "value1",
+                                  "newHeader2", "value2")));
+  }
+
+  @Test
+  public void shouldReplaceExistingHeader() throws Exception {
+    Map<String, String> newHeaders = ImmutableMap.of("newHeader", "value1", "old", "value2");
+
+    assertThat(requestWithHeader("/foo", "old", "value").withHeaders(newHeaders).headers(),
+               is(ImmutableMap.of("old", "value2",
+                                  "newHeader", "value1")));
+  }
+
+  @Test
+  public void shouldClearHeaders() throws Exception {
+    assertThat(requestWithHeader("/foo", "old", "value").clearHeaders().headers(),
+               is(ImmutableMap.of()));
+  }
+}


### PR DESCRIPTION
Fixes a couple of reported issues, improves javadoc comments, and ensures that the maps exposed by Request are safe/not modifiable.