### PR TITLE
improve test of http client timeouts

### DIFF
--- a/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/SleepCallback.java
+++ b/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/SleepCallback.java
@@ -28,7 +28,7 @@ public class SleepCallback implements ExpectationCallback {
   @Override
   public HttpResponse handle(final HttpRequest httpRequest) {
     try {
-      Thread.sleep(2000);
+      Thread.sleep(1000);
     } catch (InterruptedException e) {
       return HttpResponse.response().withStatusCode(500);
     }


### PR DESCRIPTION
The previous didn't fail if no SocketTimeoutException was thrown. This one does, and I also changed a couple of constants so as to reduce the test run time a bit.