### PR TITLE
remove redundant request tracking

### DIFF
--- a/apollo-api-impl/src/main/java/com/spotify/apollo/request/GatheringEndpointRunnableFactory.java
+++ b/apollo-api-impl/src/main/java/com/spotify/apollo/request/GatheringEndpointRunnableFactory.java
@@ -24,22 +24,18 @@ import com.spotify.apollo.dispatch.Endpoint;
 import com.spotify.apollo.meta.IncomingCallsGatherer;
 
 /**
- * An {@link EndpointRunnableFactory} that collect statistics
+ * An {@link EndpointRunnableFactory} that gathers incoming calls.
  */
-@Deprecated
-class TrackingEndpointRunnableFactory implements EndpointRunnableFactory {
+class GatheringEndpointRunnableFactory implements EndpointRunnableFactory {
 
   private final EndpointRunnableFactory delegate;
   private final IncomingCallsGatherer incomingCallsGatherer;
-  private final RequestTracker requestTracker;
 
-  TrackingEndpointRunnableFactory(
+  GatheringEndpointRunnableFactory(
       EndpointRunnableFactory delegate,
-      IncomingCallsGatherer incomingCallsGatherer,
-      RequestTracker requestTracker) {
+      IncomingCallsGatherer incomingCallsGatherer) {
     this.delegate = delegate;
     this.incomingCallsGatherer = incomingCallsGatherer;
-    this.requestTracker = requestTracker;
   }
 
   public Runnable create(
@@ -49,9 +45,6 @@ class TrackingEndpointRunnableFactory implements EndpointRunnableFactory {
 
     incomingCallsGatherer.gatherIncomingCall(ongoingRequest, endpoint);
 
-    final OngoingRequest trackedRequest =
-        new TrackedOngoingRequestImpl(ongoingRequest, requestTracker);
-
-    return delegate.create(trackedRequest, requestContext, endpoint);
+    return delegate.create(ongoingRequest, requestContext, endpoint);
   }
 }

--- a/apollo-api-impl/src/main/java/com/spotify/apollo/request/Handlers.java
+++ b/apollo-api-impl/src/main/java/com/spotify/apollo/request/Handlers.java
@@ -54,6 +54,7 @@ public final class Handlers {
     return new EndpointInvocationHandler();
   }
 
+  @Deprecated
   public static EndpointRunnableFactory withTracking(
       EndpointRunnableFactory endpointRunnableFactory,
       IncomingCallsGatherer incomingCallsGatherer,
@@ -63,5 +64,13 @@ public final class Handlers {
         endpointRunnableFactory,
         incomingCallsGatherer,
         requestTracker);
+  }
+
+  public static EndpointRunnableFactory withGathering(
+      final EndpointRunnableFactory endpointRunnableFactory,
+      final IncomingCallsGatherer incomingCallsGatherer) {
+    return new GatheringEndpointRunnableFactory(
+        endpointRunnableFactory,
+        incomingCallsGatherer);
   }
 }

--- a/apollo-api-impl/src/main/java/com/spotify/apollo/request/RequestTracker.java
+++ b/apollo-api-impl/src/main/java/com/spotify/apollo/request/RequestTracker.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.common.util.concurrent.Futures.getUnchecked;
 
+@Deprecated
 public class RequestTracker implements Closeable {
 
   private static final Logger LOG = LoggerFactory.getLogger(RequestTracker.class);

--- a/apollo-api-impl/src/main/java/com/spotify/apollo/request/TrackedOngoingRequestImpl.java
+++ b/apollo-api-impl/src/main/java/com/spotify/apollo/request/TrackedOngoingRequestImpl.java
@@ -23,6 +23,7 @@ import com.spotify.apollo.Response;
 
 import okio.ByteString;
 
+@Deprecated
 class TrackedOngoingRequestImpl extends ForwardingOngoingRequest {
 
   private final RequestTracker requestTracker;

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/request/GatheringEndpointRunnableFactoryTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/request/GatheringEndpointRunnableFactoryTest.java
@@ -1,0 +1,79 @@
+/*
+ * -\-\-
+ * Spotify Apollo API Implementations
+ * --
+ * Copyright (C) 2013 - 2015 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.request;
+
+import com.spotify.apollo.Request;
+import com.spotify.apollo.RequestContext;
+import com.spotify.apollo.dispatch.Endpoint;
+import com.spotify.apollo.dispatch.EndpointInfo;
+import com.spotify.apollo.meta.IncomingCallsGatherer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GatheringEndpointRunnableFactoryTest {
+
+  @Mock IncomingCallsGatherer incomingCallsGatherer;
+
+  @Mock OngoingRequest ongoingRequest;
+  @Mock RequestContext requestContext;
+  @Mock Endpoint endpoint;
+  @Mock EndpointInfo info;
+
+  @Mock EndpointRunnableFactory delegate;
+  @Mock Runnable delegateRunnable;
+
+  GatheringEndpointRunnableFactory endpointRunnableFactory;
+
+  @Before
+  public void setUp() throws Exception {
+    when(ongoingRequest.request()).thenReturn(Request.forUri("http://foo"));
+    when(endpoint.info()).thenReturn(info);
+    when(info.getName()).thenReturn("foo");
+
+    when(delegate.create(any(), any(), any())).thenReturn(delegateRunnable);
+
+    endpointRunnableFactory = new GatheringEndpointRunnableFactory(
+        delegate, incomingCallsGatherer);
+  }
+
+  @Test
+  public void shouldRunDelegate() throws Exception {
+    endpointRunnableFactory.create(ongoingRequest, requestContext, endpoint).run();
+
+    verify(delegateRunnable).run();
+  }
+
+  @Test
+  public void shouldGatherCalls() throws Exception {
+    endpointRunnableFactory.create(ongoingRequest, requestContext, endpoint).run();
+
+    verify(incomingCallsGatherer).gatherIncomingCall(eq(ongoingRequest), eq(endpoint));
+  }
+}

--- a/apollo-environment/README.md
+++ b/apollo-environment/README.md
@@ -82,7 +82,7 @@ The decoration chain looks like:
 
 ### EndpointRunnableFactory
 
-1. [`TrackingEndpointRunnableFactory`](../apollo-api-impl/src/main/java/com/spotify/apollo/request/TrackingEndpointRunnableFactory.java)
+1. [`GatheringEndpointRunnableFactory`](../apollo-api-impl/src/main/java/com/spotify/apollo/request/GatheringEndpointRunnableFactory.java)
 1. [`[EndpointRunnableFactory]*`](../apollo-api-impl/src/main/java/com/spotify/apollo/request/EndpointRunnableFactory.java) <- [`Set<EndpointRunnableFactoryDecorator>`](../apollo-environment/src/main/java/com/spotify/apollo/environment/EndpointRunnableFactoryDecorator.java)
 1. [`EndpointInvocationHandler`](../apollo-api-impl/src/main/java/com/spotify/apollo/dispatch/EndpointInvocationHandler.java)
 

--- a/apollo-environment/src/main/java/com/spotify/apollo/environment/ApolloEnvironmentModule.java
+++ b/apollo-environment/src/main/java/com/spotify/apollo/environment/ApolloEnvironmentModule.java
@@ -37,7 +37,6 @@ import com.spotify.apollo.module.AbstractApolloModule;
 import com.spotify.apollo.request.EndpointRunnableFactory;
 import com.spotify.apollo.request.RequestHandler;
 import com.spotify.apollo.request.RequestRunnableFactory;
-import com.spotify.apollo.request.RequestTracker;
 import com.spotify.apollo.route.ApplicationRouter;
 import com.spotify.apollo.route.Routers;
 import com.typesafe.config.Config;
@@ -53,7 +52,7 @@ import javax.inject.Singleton;
 import static com.spotify.apollo.request.Handlers.endpointRunnableFactory;
 import static com.spotify.apollo.request.Handlers.requestHandler;
 import static com.spotify.apollo.request.Handlers.requestRunnableFactory;
-import static com.spotify.apollo.request.Handlers.withTracking;
+import static com.spotify.apollo.request.Handlers.withGathering;
 
 /**
  * A module setting up implementations of Apollo API Framework components such as {@link
@@ -184,16 +183,14 @@ public class ApolloEnvironmentModule extends AbstractApolloModule {
       final EndpointRunnableFactory decoratedEndpointRunnableFactory =
           foldDecorators(baseEndpointRunnableFactory, erfDecorators);
 
-      final RequestTracker requestTracker = new RequestTracker();
       final RequestHandler requestHandler = requestHandler(
           decoratedRequestRunnableFactory,
-          withTracking(
+          withGathering(
               decoratedEndpointRunnableFactory,
-              metaInfoTracker.incomingCallsGatherer(),
-              requestTracker),
+              metaInfoTracker.incomingCallsGatherer()
+          ),
           incomingRequestAwareClient);
 
-      closer.register(requestTracker);
       closer.register(() -> LOG.info("Shutting down Apollo instance"));
 
       return requestHandler;


### PR DESCRIPTION
Both jetty and hermes servers handle request timeouts so there is no need for apollo to also perform incoming request timeout tracking.