### PR TITLE
Add apollo-entity middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
+Apollo
+======
+
 [![Circle Status](https://circleci.com/gh/spotify/apollo.svg?style=shield&circle-token=5a9eb086ae3cec87e62fc8b6cdeb783cb318e3b9)](https://circleci.com/gh/spotify/apollo)
 [![Coverage Status](https://coveralls.io/repos/spotify/apollo/badge.svg?branch=master&service=github)](https://coveralls.io/github/spotify/apollo?branch=master)
 [![Maven Central](https://img.shields.io/maven-central/v/com.spotify/apollo-parent.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.spotify%22%20apollo*)
 [![License](https://img.shields.io/github/license/spotify/apollo.svg)](LICENSE.txt)
-
-Apollo
-======
 
 Apollo is a set of Java libraries that we use at Spotify when writing microservices. Apollo includes modules such as an HTTP server and a URI routing system, making it trivial to implement restful API services. 
 

--- a/apollo-bom/pom.xml
+++ b/apollo-bom/pom.xml
@@ -170,7 +170,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.12</version>
+                <version>1.7.16</version>
             </dependency>
 
             <dependency>

--- a/apollo-bom/pom.xml
+++ b/apollo-bom/pom.xml
@@ -71,6 +71,11 @@
             </dependency>
             <dependency>
                 <groupId>com.spotify</groupId>
+                <artifactId>apollo-entity</artifactId>
+                <version>1.0.5-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.spotify</groupId>
                 <artifactId>apollo-http-service</artifactId>
                 <version>1.0.5-SNAPSHOT</version>
             </dependency>

--- a/apollo-bom/pom.xml
+++ b/apollo-bom/pom.xml
@@ -142,6 +142,11 @@
                 <version>1.2.1</version>
             </dependency>
             <dependency>
+                <groupId>io.javaslang</groupId>
+                <artifactId>javaslang</artifactId>
+                <version>2.0.2</version>
+            </dependency>
+            <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>1.1.3</version>

--- a/apollo-entity/README.md
+++ b/apollo-entity/README.md
@@ -127,4 +127,4 @@ See [`EntityTest`][2] for a complete list of route options and tests.
 
 [1]: src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
 [2]: src/test/java/com/spotify/apollo/entity/EntityTest.java
-[project skeleton]: https://github.com/spotify/apollo/tree/master/apollo-http-service#minimal-project-skeleton
+[project skeleton]: https://github.com/spotify/apollo/tree/master/apollo-http-service#maven

--- a/apollo-entity/README.md
+++ b/apollo-entity/README.md
@@ -55,7 +55,7 @@ class MyApplication {
 
   static void init(Environment environment) {
     MyApplication app = new MyApplication();
-    EntityMiddleware entity = EntityMiddleware.jackson(OBJECT_MAPPER);
+    EntityMiddleware entity = EntityMiddleware.forJackson(OBJECT_MAPPER);
 
     Route<SyncHandler<Response<ByteString>>> route = Route.with(
         entity.direct(Person.class),
@@ -70,6 +70,10 @@ class MyApplication {
   }
 }
 ```
+
+[`EntityMiddleware`][1] also support custom codecs through the `forCodec(EntityCodec)` static
+constructor. An [`EntityCodec`][2] defines how to read and write entity types from the `ByteString`
+payloads that apollo handle natively.
 
 ## Handler signatures
 
@@ -127,8 +131,9 @@ rc -> this::handler
 
 ---
 
-See [`EntityTest`][2] for a complete list of route options and tests.
+See [`EntityMiddlewareTest`][3] for a complete list of route options and tests.
 
 [1]: src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
-[2]: src/test/java/com/spotify/apollo/entity/EntityTest.java
+[2]: src/main/java/com/spotify/apollo/entity/EntityCodec.java
+[3]: src/test/java/com/spotify/apollo/entity/EntityMiddlewareTest.java
 [project skeleton]: https://github.com/spotify/apollo/tree/master/apollo-http-service#maven

--- a/apollo-entity/README.md
+++ b/apollo-entity/README.md
@@ -76,14 +76,16 @@ class MyApplication {
 The [`EntityMiddleware`][1] interface can create middlewares for several types of handler
 signatures.
 
-* `direct(E.class)` middleware : `EntityHandler<E, R>`
+* `direct(E.class[, R.class])` middleware : `EntityHandler<E, R>`
  - `R handler(E)`
-* `response(E.class)` middleware : `EntityResponseHandler<E, R>`
+* `response(E.class[, R.class])` middleware : `EntityResponseHandler<E, R>`
  - `Response<R> handler(E)`
-* `asyncDirect(E.class)` middleware : `EntityAsyncHandler<E, R>`
+* `asyncDirect(E.class[, R.class])` middleware : `EntityAsyncHandler<E, R>`
  - `CompletionStage<R> handler(E)`
-* `asyncResponse(E.class)` middleware : `EntityAsyncResponseHandler<E, R>`
+* `asyncResponse(E.class[, R.class])` middleware : `EntityAsyncResponseHandler<E, R>`
   - `CompletionStage<Response<R>> handler(E)`
+
+For all of the above, if the reply entity type `R` is omitted it will be set to the same as `E`.
 
 On top of these, there's also just a serializing middleware for handlers that do not take a
 request entity as an input.
@@ -97,9 +99,9 @@ request entity as an input.
 * `asyncSerializerResponse(R.class)` middleware : `AsyncHandler<Response<R>>`
  - `CompletionStage<Response<R>> handler()`
 
-All of the `Entity*` handler signatures are in curried form with a `RequestContext` as the first
-argument. This give you the flexibility to add more arguments to your handlers as you see fit,
-while also being easy to compose.
+All of the `Entity*Handler<E, R>` handler signatures are in curried form with a `RequestContext`
+as the first argument. This give you the flexibility to add more arguments to your handlers as you
+see fit, while also being easy to compose.
 
 ```java
 rc -> entity -> handler(entity, ...)

--- a/apollo-entity/README.md
+++ b/apollo-entity/README.md
@@ -55,7 +55,7 @@ class MyApplication {
 
   static void init(Environment environment) {
     MyApplication app = new MyApplication();
-    EntityMiddleware entity = EntityMiddleware.forJackson(OBJECT_MAPPER);
+    EntityMiddleware entity = EntityMiddleware.forCodec(JacksonEntityCodec.forMapper(OBJECT_MAPPER));
 
     Route<SyncHandler<Response<ByteString>>> route = Route.with(
         entity.direct(Person.class),
@@ -73,7 +73,8 @@ class MyApplication {
 
 [`EntityMiddleware`][1] also support custom codecs through the `forCodec(EntityCodec)` static
 constructor. An [`EntityCodec`][2] defines how to read and write entity types from the `ByteString`
-payloads that apollo handle natively.
+payloads that apollo handle natively. Since Jackson is so commonly used, we have a bundled
+implementation called [`JacksonEntityCodec`][4].
 
 ## Handler signatures
 
@@ -136,4 +137,5 @@ See [`EntityMiddlewareTest`][3] for a complete list of route options and tests.
 [1]: src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
 [2]: src/main/java/com/spotify/apollo/entity/EntityCodec.java
 [3]: src/test/java/com/spotify/apollo/entity/EntityMiddlewareTest.java
+[4]: src/main/java/com/spotify/apollo/entity/JacksonEntityCodec.java
 [project skeleton]: https://github.com/spotify/apollo/tree/master/apollo-http-service#maven

--- a/apollo-entity/README.md
+++ b/apollo-entity/README.md
@@ -1,0 +1,126 @@
+# Apollo Entity
+
+A set of Apollo Middleware for working with entity types in route handlers.
+
+## Why
+
+A common pattern when writing route handlers is to serialize and deserialize to some API level
+entity types. Writing such (de)serialization code quickly becomes repetitive and always looks
+the same.
+
+Ideally, one would like to have endpoint handlers with straight forward signatures like
+
+```java
+Person updatePerson(String id, Person person) {
+  // ...
+}
+```
+
+With a route defined as:
+
+```java
+Route.sync(
+    "PUT", "/person/<id>",
+    rc -> person -> updatePerson(rc.pathArgs().get("id"), person))
+```
+
+However, this does not work. Theres nothing handling how the `Person` type is being read to and
+from a `ByteString` which is the payload type Apollo works with.
+
+At this point, you'll start writing some custom middlewares using something like Jackson. This
+library contains exactly those middlewares, ready to use directly with your routes.
+
+
+## Getting started
+
+Add Maven dependency:
+
+```xml
+<dependency>
+    <groupId>com.spotify</groupId>
+    <artifactId>apollo-entity</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+</dependency>
+```
+
+Create your Jackson `ObjectMapper` and the [`EntityMiddleware`][1] factory:
+
+```java
+class MyApplication {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  static void init(Environment environment) {
+    MyApplication app = new MyApplication();
+    EntityMiddleware entity = EntityMiddleware.jackson(OBJECT_MAPPER);
+
+    Route<SyncHandler<Response<ByteString>>> route = Route.with(
+        entity.direct(Person.class),
+        "PUT", "/person/<id>",
+        rc -> person -> app.updatePerson(rc.pathArgs().get("id"), person));
+
+    // ...
+  }
+
+  Person updatePerson(String id, Person person) {
+    // ...
+  }
+}
+```
+
+## Handler signatures
+
+The [`EntityMiddleware`][1] interface can create middlewares for several types of handler
+signatures.
+
+* `direct(E.class)` middleware : `EntityHandler<E, R>`
+ - `R handler(E)`
+* `response(E.class)` middleware : `EntityResponseHandler<E, R>`
+ - `Response<R> handler(E)`
+* `asyncDirect(E.class)` middleware : `EntityAsyncHandler<E, R>`
+ - `CompletionStage<R> handler(E)`
+* `asyncResponse(E.class)` middleware : `EntityAsyncResponseHandler<E, R>`
+  - `CompletionStage<Response<R>> handler(E)`
+
+On top of these, there's also just a serializing middleware for handlers that do not take a
+request entity as an input.
+
+* `serializerDirect()` middleware : `SyncHandler<R>`
+ - `R handler()`
+* `serializerResponse()` middleware : `SyncHandler<Response<R>>`
+ - `Response<R> handler()`
+* `asyncSerializerDirect()` middleware : `AsyncHandler<R>`
+ - `CompletionStage<R> handler()`
+* `asyncSerializerResponse()` middleware : `AsyncHandler<Response<R>>`
+ - `CompletionStage<Response<R>> handler()`
+
+All of the `Entity*` handler signatures are in curried form with a `RequestContext` as the first
+argument. This give you the flexibility to add more arguments to your handlers as you see fit,
+while also being easy to compose.
+
+```java
+rc -> entity -> handler(entity, ...)
+```
+
+Works well with closures around handlers:
+
+```java
+rc -> updatePersonWithId(rc.pathArgs().get("id"))
+
+UnaryOperator<Person> updatePersonWithId(String id) {
+  return person -> ...;
+}
+```
+
+In the case nothing else is needed from the request context, this reduces to:
+
+```java
+rc -> this::handler
+```
+
+---
+
+See [`EntityTest`][2] for a complete list of route options and tests.
+
+[1]: src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
+[2]: src/test/java/com/spotify/apollo/entity/EntityTest.java

--- a/apollo-entity/README.md
+++ b/apollo-entity/README.md
@@ -1,4 +1,5 @@
-# Apollo Entity
+Apollo Entity
+=============
 
 A set of Apollo Middleware for working with entity types in route handlers.
 
@@ -39,9 +40,11 @@ Add Maven dependency:
 <dependency>
     <groupId>com.spotify</groupId>
     <artifactId>apollo-entity</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.5</version>
 </dependency>
 ```
+
+_See the [project skeleton] docs for how to use a Maven BOM for dependency versions_
 
 Create your Jackson `ObjectMapper` and the [`EntityMiddleware`][1] factory:
 
@@ -124,3 +127,4 @@ See [`EntityTest`][2] for a complete list of route options and tests.
 
 [1]: src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
 [2]: src/test/java/com/spotify/apollo/entity/EntityTest.java
+[project skeleton]: https://github.com/spotify/apollo/tree/master/apollo-http-service#minimal-project-skeleton

--- a/apollo-entity/README.md
+++ b/apollo-entity/README.md
@@ -88,13 +88,13 @@ signatures.
 On top of these, there's also just a serializing middleware for handlers that do not take a
 request entity as an input.
 
-* `serializerDirect()` middleware : `SyncHandler<R>`
+* `serializerDirect(R.class)` middleware : `SyncHandler<R>`
  - `R handler()`
-* `serializerResponse()` middleware : `SyncHandler<Response<R>>`
+* `serializerResponse(R.class)` middleware : `SyncHandler<Response<R>>`
  - `Response<R> handler()`
-* `asyncSerializerDirect()` middleware : `AsyncHandler<R>`
+* `asyncSerializerDirect(R.class)` middleware : `AsyncHandler<R>`
  - `CompletionStage<R> handler()`
-* `asyncSerializerResponse()` middleware : `AsyncHandler<Response<R>>`
+* `asyncSerializerResponse(R.class)` middleware : `AsyncHandler<Response<R>>`
  - `CompletionStage<Response<R>> handler()`
 
 All of the `Entity*` handler signatures are in curried form with a `RequestContext` as the first

--- a/apollo-entity/README.md
+++ b/apollo-entity/README.md
@@ -85,7 +85,7 @@ signatures.
 * `asyncResponse(E.class[, R.class])` middleware : `EntityAsyncResponseHandler<E, R>`
   - `CompletionStage<Response<R>> handler(E)`
 
-For all of the above, if the reply entity type `R` is omitted it will be set to the same as `E`.
+For all of the above, if the reply entity type `R.class` is omitted it will be set to the same as `E.class`.
 
 On top of these, there's also just a serializing middleware for handlers that do not take a
 request entity as an input.
@@ -98,6 +98,8 @@ request entity as an input.
  - `CompletionStage<R> handler()`
 * `asyncSerializerResponse(R.class)` middleware : `AsyncHandler<Response<R>>`
  - `CompletionStage<Response<R>> handler()`
+
+### Curried form
 
 All of the `Entity*Handler<E, R>` handler signatures are in curried form with a `RequestContext`
 as the first argument. This give you the flexibility to add more arguments to your handlers as you

--- a/apollo-entity/pom.xml
+++ b/apollo-entity/pom.xml
@@ -33,6 +33,10 @@
         </dependency>
 
         <dependency>
+            <groupId>io.javaslang</groupId>
+            <artifactId>javaslang</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/apollo-entity/pom.xml
+++ b/apollo-entity/pom.xml
@@ -1,0 +1,82 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.spotify</groupId>
+        <artifactId>apollo-parent</artifactId>
+        <version>1.0.5-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <name>Spotify Apollo Entity Middleware</name>
+    <artifactId>apollo-entity</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.spotify</groupId>
+                <artifactId>apollo-bom</artifactId>
+                <version>1.0.5-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.spotify</groupId>
+            <artifactId>apollo-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>com.spotify</groupId>
+            <artifactId>apollo-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.norberg</groupId>
+            <artifactId>auto-matter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.norberg</groupId>
+            <artifactId>auto-matter-jackson</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path-assert</artifactId>
+            <version>2.2.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
@@ -19,6 +19,7 @@
  */
 package com.spotify.apollo.entity;
 
+import com.spotify.apollo.RequestContext;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.Status;
 import com.spotify.apollo.route.AsyncHandler;
@@ -34,6 +35,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+import javaslang.control.Either;
 import okio.ByteString;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -65,30 +67,32 @@ class CodecEntityMiddleware implements EntityMiddleware {
 
   @Override
   public <R> Middleware<SyncHandler<R>, SyncHandler<Response<ByteString>>>
-  serializerDirect(Class<? extends R> entityClass) {
+  serializerDirect(Class<? extends R> entityResponseClass) {
     return inner -> inner
-        .map(this::ensureResponse)
-        .map(serialize(entityClass));
+        .map(Response::forPayload)
+        .map(serialize(entityResponseClass));
   }
 
   @Override
   public <R> Middleware<SyncHandler<Response<R>>, SyncHandler<Response<ByteString>>>
-  serializerResponse(Class<? extends R> entityClass) {
-    return inner -> inner.map(serialize(entityClass));
+  serializerResponse(Class<? extends R> entityResponseClass) {
+    return inner -> inner
+        .map(serialize(entityResponseClass));
   }
 
   @Override
   public <R> Middleware<AsyncHandler<R>, AsyncHandler<Response<ByteString>>>
-  asyncSerializerDirect(Class<? extends R> entityClass) {
+  asyncSerializerDirect(Class<? extends R> entityResponseClass) {
     return inner -> inner
-        .map(this::ensureResponse)
-        .map(serialize(entityClass));
+        .map(Response::forPayload)
+        .map(serialize(entityResponseClass));
   }
 
   @Override
   public <R> Middleware<AsyncHandler<Response<R>>, AsyncHandler<Response<ByteString>>>
-  asyncSerializerResponse(Class<? extends R> entityClass) {
-    return inner -> inner.map(serialize(entityClass));
+  asyncSerializerResponse(Class<? extends R> entityResponseClass) {
+    return inner -> inner
+        .map(serialize(entityResponseClass));
   }
 
   @Override
@@ -100,10 +104,8 @@ class CodecEntityMiddleware implements EntityMiddleware {
   @Override
   public <E, R> Middleware<EntityHandler<E, R>, SyncHandler<Response<ByteString>>>
   direct(Class<? extends E> entityClass, Class<? extends R> entityResponseClass) {
-    return inner ->
-        deserialize(entityClass)
-            .flatMap(r -> ctx -> mapPayload(r, inner.invoke(ctx)))
-            .map(serialize(entityResponseClass));
+    return inner -> withEntity(inner.asResponseHandler(), entityClass)
+        .map(serialize(entityResponseClass));
   }
 
   @Override
@@ -115,10 +117,8 @@ class CodecEntityMiddleware implements EntityMiddleware {
   @Override
   public <E, R> Middleware<EntityResponseHandler<E, R>, SyncHandler<Response<ByteString>>>
   response(Class<? extends E> entityClass, Class<? extends R> entityResponseClass) {
-    return inner ->
-        deserialize(entityClass)
-            .flatMap(r -> ctx -> flatMapPayload(r, inner.invoke(ctx)))
-            .map(serialize(entityResponseClass));
+    return inner -> withEntity(inner, entityClass)
+        .map(serialize(entityResponseClass));
   }
 
   @Override
@@ -130,10 +130,8 @@ class CodecEntityMiddleware implements EntityMiddleware {
   @Override
   public <E, R> Middleware<EntityAsyncHandler<E, R>, AsyncHandler<Response<ByteString>>>
   asyncDirect(Class<? extends E> entityClass, Class<? extends R> entityResponseClass) {
-    return inner ->
-        Middleware.syncToAsync(deserialize(entityClass))
-            .flatMap(r -> ctx -> asyncMapPayload(r, inner.invoke(ctx)))
-            .map(serialize(entityResponseClass));
+    return inner -> withEntityAsync(inner.asResponseHandler(), entityClass)
+        .map(serialize(entityResponseClass));
   }
 
   @Override
@@ -145,39 +143,53 @@ class CodecEntityMiddleware implements EntityMiddleware {
   @Override
   public <E, R> Middleware<EntityAsyncResponseHandler<E, R>, AsyncHandler<Response<ByteString>>>
   asyncResponse(Class<? extends E> entityClass, Class<? extends R> entityResponseClass) {
-    return inner ->
-        Middleware.syncToAsync(deserialize(entityClass))
-            .flatMap(r -> ctx -> asyncFlatMapPayload(r, inner.invoke(ctx)))
-            .map(serialize(entityResponseClass));
+    return inner -> withEntityAsync(inner, entityClass)
+        .map(serialize(entityResponseClass));
   }
 
-  private <E> SyncHandler<Response<E>> deserialize(Class<? extends E> entityClass) {
-    return requestContext -> {
-      final Optional<ByteString> payloadOpt = requestContext.request().payload();
-      if (!payloadOpt.isPresent()) {
-        return Response.forStatus(
-            Status.BAD_REQUEST
-                .withReasonPhrase("Missing payload"));
-      }
-
-      final E entity;
-      try {
-        final ByteString byteString = payloadOpt.get();
-        entity = codec.read(byteString.toByteArray(), entityClass);
-      } catch (IOException e) {
-        LOG.warn("error", e);
-        return Response.forStatus(
-            Status.BAD_REQUEST
-                .withReasonPhrase("Payload parsing failed: " + e.getMessage()));
-      }
-
-      return Response.forPayload(entity);
-    };
+  private <E, R> SyncHandler<Response<R>> withEntity(
+      EntityResponseHandler<E, R> inner,
+      Class<? extends E> entityClass) {
+    //noinspection unchecked
+    return rc -> deserialize(rc, entityClass)
+        .map(inner.invoke(rc))
+        .getOrElseGet(left -> (Response<R>) left);
   }
 
-  private <E> Function<Response<E>, Response<ByteString>> serialize(Class<? extends E> entityClass) {
+  private <E, R> AsyncHandler<Response<R>> withEntityAsync(
+      EntityAsyncResponseHandler<E, R> inner,
+      Class<? extends E> entityClass) {
+    //noinspection unchecked
+    return rc -> deserialize(rc, entityClass)
+        .map(inner.invoke(rc))
+        .getOrElseGet(left -> completedFuture((Response<R>) left));
+  }
+
+  private <E> Either<Response<?>, E> deserialize(RequestContext rc, Class<? extends E> entityClass) {
+    final Optional<ByteString> payloadOpt = rc.request().payload();
+    if (!payloadOpt.isPresent()) {
+      return Either.left(Response.forStatus(
+          Status.BAD_REQUEST
+              .withReasonPhrase("Missing payload")));
+    }
+
+    final E entity;
+    try {
+      final ByteString byteString = payloadOpt.get();
+      entity = codec.read(byteString.toByteArray(), entityClass);
+    } catch (IOException e) {
+      LOG.warn("error", e);
+      return Either.left(Response.forStatus(
+          Status.BAD_REQUEST
+              .withReasonPhrase("Payload parsing failed: " + e.getMessage())));
+    }
+
+    return Either.right(entity);
+  }
+
+  private <R> Function<Response<R>, Response<ByteString>> serialize(Class<? extends R> entityClass) {
     return response -> {
-      final Optional<E> entityOpt = response.payload();
+      final Optional<R> entityOpt = response.payload();
 
       if (!entityOpt.isPresent()) {
         //noinspection unchecked
@@ -197,54 +209,5 @@ class CodecEntityMiddleware implements EntityMiddleware {
       return response.withPayload(bytes)
           .withHeader(CONTENT_TYPE, contentType);
     };
-  }
-
-  private <E> Response<E> ensureResponse(E response) {
-    if (response instanceof Response) {
-      //noinspection unchecked
-      return (Response<E>) response;
-    }
-
-    return Response.forPayload(response);
-  }
-
-  private <E, R> Response<R> mapPayload(
-      Response<E> in,
-      Function<? super E, ? extends R> fn) {
-
-    //noinspection unchecked
-    return (in.payload().map(fn).isPresent())
-        ? in.withPayload(in.payload().map(fn).get())
-        : (Response<R>) in;
-  }
-
-  private <E, R> Response<R> flatMapPayload(
-      Response<E> in,
-      Function<? super E, ? extends Response<? extends R>> fn) {
-
-    //noinspection unchecked
-    return (in.payload().isPresent())
-        ? (Response<R>) fn.apply(in.payload().get()).withHeaders(in.headers())
-        : (Response<R>) in;
-  }
-
-  private <E, R> CompletionStage<Response<R>> asyncMapPayload(
-      Response<E> in,
-      Function<? super E, ? extends CompletionStage<? extends R>> fn) {
-
-    //noinspection unchecked
-    return (in.payload().isPresent())
-        ? fn.apply(in.payload().get()).thenApply(in::withPayload)
-        : completedFuture((Response<R>) in);
-  }
-
-  private <E, R> CompletionStage<Response<R>> asyncFlatMapPayload(
-      Response<E> in,
-      Function<? super E, ? extends CompletionStage<? extends Response<? extends R>>> fn) {
-
-    //noinspection unchecked
-    return (in.payload().isPresent())
-        ? fn.apply(in.payload().get()).thenApply(ret -> (Response<R>) ret.withHeaders(in.headers()))
-        : completedFuture((Response<R>) in);
   }
 }

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
@@ -174,8 +174,7 @@ class CodecEntityMiddleware implements EntityMiddleware {
 
     final E entity;
     try {
-      final ByteString byteString = payloadOpt.get();
-      entity = codec.read(byteString.toByteArray(), entityClass);
+      entity = codec.read(payloadOpt.get(), entityClass);
     } catch (IOException e) {
       LOG.warn("error", e);
       return Either.left(Response.forStatus(
@@ -197,7 +196,7 @@ class CodecEntityMiddleware implements EntityMiddleware {
 
       final ByteString bytes;
       try {
-        bytes = ByteString.of(codec.write(entityOpt.get(), entityClass));
+        bytes = codec.write(entityOpt.get(), entityClass);
       } catch (IOException e) {
         LOG.error("error", e);
         return Response.forStatus(

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
@@ -50,13 +50,12 @@ class CodecEntityMiddleware implements EntityMiddleware {
   private static final Logger LOG = LoggerFactory.getLogger(CodecEntityMiddleware.class);
 
   private static final String CONTENT_TYPE = "Content-Type";
-  private static final String DEFAULT_CONTENT_TYPE = "application/json";
 
   private final EntityCodec codec;
   private final String contentType;
 
   CodecEntityMiddleware(EntityCodec codec) {
-    this(codec, DEFAULT_CONTENT_TYPE);
+    this(codec, codec.defaultContentType());
   }
 
   CodecEntityMiddleware(EntityCodec codec, String contentType) {

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
@@ -39,8 +39,11 @@ import okio.ByteString;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 /**
- * A factory for creating middlewares that can be used to jackson the routes that deal directly
+ * A factory for creating middlewares that can be used to create routes that deal directly
  * with an api entity.
+ *
+ * A {@link EntityCodec} is used to define how to go between a {@link ByteString} and the
+ * entity type used in your route handlers.
  */
 class CodecEntityMiddleware implements EntityMiddleware {
 

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
@@ -1,0 +1,226 @@
+/*
+ * -\-\-
+ * Spotify Apollo Entity Middleware
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.entity;
+
+import com.spotify.apollo.Response;
+import com.spotify.apollo.Status;
+import com.spotify.apollo.route.AsyncHandler;
+import com.spotify.apollo.route.Middleware;
+import com.spotify.apollo.route.SyncHandler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import okio.ByteString;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+/**
+ * A factory for creating middlewares that can be used to jackson the routes that deal directly
+ * with an api entity.
+ */
+class CodecEntityMiddleware implements EntityMiddleware {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CodecEntityMiddleware.class);
+
+  private static final String CONTENT_TYPE = "Content-Type";
+  private static final String DEFAULT_CONTENT_TYPE = "application/json";
+
+  private final EntityCodec codec;
+  private final String contentType;
+
+  CodecEntityMiddleware(EntityCodec codec) {
+    this(codec, DEFAULT_CONTENT_TYPE);
+  }
+
+  CodecEntityMiddleware(EntityCodec codec, String contentType) {
+    this.codec = Objects.requireNonNull(codec);
+    this.contentType = Objects.requireNonNull(contentType);
+  }
+
+  @Override
+  public <R> Middleware<SyncHandler<R>, SyncHandler<Response<ByteString>>>
+  serializerDirect(Class<? extends R> entityClass) {
+    return inner -> inner
+        .map(this::ensureResponse)
+        .map(serialize(entityClass));
+  }
+
+  @Override
+  public <R> Middleware<SyncHandler<Response<R>>, SyncHandler<Response<ByteString>>>
+  serializerResponse(Class<? extends R> entityClass) {
+    return inner -> inner.map(serialize(entityClass));
+  }
+
+  @Override
+  public <R> Middleware<AsyncHandler<R>, AsyncHandler<Response<ByteString>>>
+  asyncSerializerDirect(Class<? extends R> entityClass) {
+    return inner -> inner
+        .map(this::ensureResponse)
+        .map(serialize(entityClass));
+  }
+
+  @Override
+  public <R> Middleware<AsyncHandler<Response<R>>, AsyncHandler<Response<ByteString>>>
+  asyncSerializerResponse(Class<? extends R> entityClass) {
+    return inner -> inner.map(serialize(entityClass));
+  }
+
+  @Override
+  public <E> Middleware<EntityHandler<E, ?>, SyncHandler<Response<ByteString>>>
+  direct(Class<? extends E> entityClass) {
+    return inner ->
+        deserialize(entityClass)
+            .flatMap(r -> ctx -> mapPayload(r, inner.invoke(ctx)))
+            .map(serialize(entityClass));
+  }
+
+  @Override
+  public <E> Middleware<EntityResponseHandler<E, ?>, SyncHandler<Response<ByteString>>>
+  response(Class<? extends E> entityClass) {
+    return inner ->
+        deserialize(entityClass)
+            .flatMap(r -> ctx -> flatMapPayload(r, inner.invoke(ctx)))
+            .map(serialize(entityClass));
+  }
+
+  @Override
+  public <E> Middleware<EntityAsyncHandler<E, ?>, AsyncHandler<Response<ByteString>>> asyncDirect(
+      Class<? extends E> entityClass) {
+    return inner ->
+        Middleware.syncToAsync(deserialize(entityClass))
+            .flatMap(r -> ctx -> completedFuture(r).thenCompose(asyncInvoke(inner.invoke(ctx))))
+            .map(serialize(entityClass));
+  }
+
+  @Override
+  public <E> Middleware<EntityAsyncResponseHandler<E, ?>, AsyncHandler<Response<ByteString>>>
+  asyncResponse(Class<? extends E> entityClass) {
+    return inner ->
+        Middleware.syncToAsync(deserialize(entityClass))
+            .flatMap(r -> ctx -> completedFuture(r).thenCompose(asyncMerge(inner.invoke(ctx))))
+            .map(serialize(entityClass));
+  }
+
+  private <E> SyncHandler<Response<E>> deserialize(Class<? extends E> entityClass) {
+    return requestContext -> {
+      final Optional<ByteString> payloadOpt = requestContext.request().payload();
+      if (!payloadOpt.isPresent()) {
+        return Response.forStatus(
+            Status.BAD_REQUEST
+                .withReasonPhrase("Missing payload"));
+      }
+
+      final E entity;
+      try {
+        final ByteString byteString = payloadOpt.get();
+        entity = codec.read(byteString.toByteArray(), entityClass);
+      } catch (IOException e) {
+        LOG.warn("error", e);
+        return Response.forStatus(
+            Status.BAD_REQUEST
+                .withReasonPhrase("Payload parsing failed: " + e.getMessage()));
+      }
+
+      return Response.forPayload(entity);
+    };
+  }
+
+  private <E> Function<Response<E>, Response<ByteString>> serialize(Class<? extends E> entityClass) {
+    return response -> {
+      final Optional<E> entityOpt = response.payload();
+
+      if (!entityOpt.isPresent()) {
+        //noinspection unchecked
+        return (Response<ByteString>) response;
+      }
+
+      final ByteString bytes;
+      try {
+        bytes = ByteString.of(codec.write(entityOpt.get(), entityClass));
+      } catch (IOException e) {
+        LOG.error("error", e);
+        return Response.forStatus(
+            Status.INTERNAL_SERVER_ERROR
+                .withReasonPhrase("Payload serialization failed: " + e.getMessage()));
+      }
+
+      return response.withPayload(bytes)
+          .withHeader(CONTENT_TYPE, contentType);
+    };
+  }
+
+  private <E, R> Function<Response<E>, CompletionStage<Response<R>>> asyncInvoke(
+      Function<? super E, ? extends CompletionStage<? extends R>> fn) {
+    //noinspection unchecked
+    return in -> in.payload().isPresent()
+        ? fn.apply(in.payload().get()).thenApply(in::withPayload)
+        : completedFuture((Response<R>) in);
+  }
+
+  private <E, R> Function<Response<E>, CompletionStage<Response<R>>> asyncMerge(
+      Function<? super E, ? extends CompletionStage<? extends Response<? extends R>>> fn) {
+    //noinspection unchecked
+    return in -> in.payload().isPresent()
+        ? fn.apply(in.payload().get()).thenApply(other -> (Response<R>) other.withHeaders(in.headers()))
+        : completedFuture((Response<R>) in);
+  }
+
+  private <E> Response<E> ensureResponse(E response) {
+    if (response instanceof Response) {
+      //noinspection unchecked
+      return (Response<E>) response;
+    }
+
+    return Response.forPayload(response);
+  }
+
+  private <E, R> Response<R> mapPayload(
+      Response<E> resp,
+      Function<? super E, ? extends R> fn) {
+    final Optional<R> entityOpt = resp.payload().map(fn);
+
+    //noinspection unchecked
+    return (entityOpt.isPresent())
+        ? resp.withPayload(entityOpt.get())
+        : (Response<R>) resp;
+  }
+
+  private <E, R> Response<R> flatMapPayload(
+      Response<E> resp,
+      Function<? super E, ? extends Response<? extends R>> fn) {
+    final Optional<E> entityOpt = resp.payload();
+
+    if (!entityOpt.isPresent()) {
+      //noinspection unchecked
+      return (Response<R>) resp;
+    }
+
+    //noinspection unchecked
+    return (Response<R>) fn.apply(entityOpt.get())
+        .withHeaders(resp.headers());
+  }
+}

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
@@ -92,39 +92,63 @@ class CodecEntityMiddleware implements EntityMiddleware {
   }
 
   @Override
-  public <E> Middleware<EntityHandler<E, ?>, SyncHandler<Response<ByteString>>>
+  public <E> Middleware<EntityHandler<E, E>, SyncHandler<Response<ByteString>>>
   direct(Class<? extends E> entityClass) {
+    return direct(entityClass, entityClass);
+  }
+
+  @Override
+  public <E, R> Middleware<EntityHandler<E, R>, SyncHandler<Response<ByteString>>>
+  direct(Class<? extends E> entityClass, Class<? extends R> entityResponseClass) {
     return inner ->
         deserialize(entityClass)
             .flatMap(r -> ctx -> mapPayload(r, inner.invoke(ctx)))
-            .map(serialize(entityClass));
+            .map(serialize(entityResponseClass));
   }
 
   @Override
-  public <E> Middleware<EntityResponseHandler<E, ?>, SyncHandler<Response<ByteString>>>
+  public <E> Middleware<EntityResponseHandler<E, E>, SyncHandler<Response<ByteString>>>
   response(Class<? extends E> entityClass) {
+    return response(entityClass, entityClass);
+  }
+
+  @Override
+  public <E, R> Middleware<EntityResponseHandler<E, R>, SyncHandler<Response<ByteString>>>
+  response(Class<? extends E> entityClass, Class<? extends R> entityResponseClass) {
     return inner ->
         deserialize(entityClass)
             .flatMap(r -> ctx -> flatMapPayload(r, inner.invoke(ctx)))
-            .map(serialize(entityClass));
+            .map(serialize(entityResponseClass));
   }
 
   @Override
-  public <E> Middleware<EntityAsyncHandler<E, ?>, AsyncHandler<Response<ByteString>>> asyncDirect(
-      Class<? extends E> entityClass) {
+  public <E> Middleware<EntityAsyncHandler<E, E>, AsyncHandler<Response<ByteString>>>
+  asyncDirect(Class<? extends E> entityClass) {
+    return asyncDirect(entityClass, entityClass);
+  }
+
+  @Override
+  public <E, R> Middleware<EntityAsyncHandler<E, R>, AsyncHandler<Response<ByteString>>>
+  asyncDirect(Class<? extends E> entityClass, Class<? extends R> entityResponseClass) {
     return inner ->
         Middleware.syncToAsync(deserialize(entityClass))
             .flatMap(r -> ctx -> asyncMapPayload(r, inner.invoke(ctx)))
-            .map(serialize(entityClass));
+            .map(serialize(entityResponseClass));
   }
 
   @Override
-  public <E> Middleware<EntityAsyncResponseHandler<E, ?>, AsyncHandler<Response<ByteString>>>
+  public <E> Middleware<EntityAsyncResponseHandler<E, E>, AsyncHandler<Response<ByteString>>>
   asyncResponse(Class<? extends E> entityClass) {
+    return asyncResponse(entityClass, entityClass);
+  }
+
+  @Override
+  public <E, R> Middleware<EntityAsyncResponseHandler<E, R>, AsyncHandler<Response<ByteString>>>
+  asyncResponse(Class<? extends E> entityClass, Class<? extends R> entityResponseClass) {
     return inner ->
         Middleware.syncToAsync(deserialize(entityClass))
             .flatMap(r -> ctx -> asyncFlatMapPayload(r, inner.invoke(ctx)))
-            .map(serialize(entityClass));
+            .map(serialize(entityResponseClass));
   }
 
   private <E> SyncHandler<Response<E>> deserialize(Class<? extends E> entityClass) {

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 import javaslang.control.Either;
@@ -152,7 +151,7 @@ class CodecEntityMiddleware implements EntityMiddleware {
       Class<? extends E> entityClass) {
     //noinspection unchecked
     return rc -> deserialize(rc, entityClass)
-        .map(inner.invoke(rc))
+        .map(inner.apply(rc))
         .getOrElseGet(left -> (Response<R>) left);
   }
 
@@ -161,7 +160,7 @@ class CodecEntityMiddleware implements EntityMiddleware {
       Class<? extends E> entityClass) {
     //noinspection unchecked
     return rc -> deserialize(rc, entityClass)
-        .map(inner.invoke(rc))
+        .map(inner.apply(rc))
         .getOrElseGet(left -> completedFuture((Response<R>) left));
   }
 

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/CodecEntityMiddleware.java
@@ -67,84 +67,84 @@ class CodecEntityMiddleware implements EntityMiddleware {
 
   @Override
   public <R> Middleware<SyncHandler<R>, SyncHandler<Response<ByteString>>>
-  serializerDirect(Class<? extends R> entityResponseClass) {
+  serializerDirect(Class<? extends R> responseEntityClass) {
     return inner -> inner
         .map(Response::forPayload)
-        .map(serialize(entityResponseClass));
+        .map(serialize(responseEntityClass));
   }
 
   @Override
   public <R> Middleware<SyncHandler<Response<R>>, SyncHandler<Response<ByteString>>>
-  serializerResponse(Class<? extends R> entityResponseClass) {
+  serializerResponse(Class<? extends R> responseEntityClass) {
     return inner -> inner
-        .map(serialize(entityResponseClass));
+        .map(serialize(responseEntityClass));
   }
 
   @Override
   public <R> Middleware<AsyncHandler<R>, AsyncHandler<Response<ByteString>>>
-  asyncSerializerDirect(Class<? extends R> entityResponseClass) {
+  asyncSerializerDirect(Class<? extends R> responseEntityClass) {
     return inner -> inner
         .map(Response::forPayload)
-        .map(serialize(entityResponseClass));
+        .map(serialize(responseEntityClass));
   }
 
   @Override
   public <R> Middleware<AsyncHandler<Response<R>>, AsyncHandler<Response<ByteString>>>
-  asyncSerializerResponse(Class<? extends R> entityResponseClass) {
+  asyncSerializerResponse(Class<? extends R> responseEntityClass) {
     return inner -> inner
-        .map(serialize(entityResponseClass));
+        .map(serialize(responseEntityClass));
   }
 
   @Override
   public <E> Middleware<EntityHandler<E, E>, SyncHandler<Response<ByteString>>>
-  direct(Class<? extends E> entityClass) {
-    return direct(entityClass, entityClass);
+  direct(Class<? extends E> requestEntityClass) {
+    return direct(requestEntityClass, requestEntityClass);
   }
 
   @Override
   public <E, R> Middleware<EntityHandler<E, R>, SyncHandler<Response<ByteString>>>
-  direct(Class<? extends E> entityClass, Class<? extends R> entityResponseClass) {
-    return inner -> withEntity(inner.asResponseHandler(), entityClass)
-        .map(serialize(entityResponseClass));
+  direct(Class<? extends E> requestEntityClass, Class<? extends R> responseEntityClass) {
+    return inner -> withEntity(inner.asResponseHandler(), requestEntityClass)
+        .map(serialize(responseEntityClass));
   }
 
   @Override
   public <E> Middleware<EntityResponseHandler<E, E>, SyncHandler<Response<ByteString>>>
-  response(Class<? extends E> entityClass) {
-    return response(entityClass, entityClass);
+  response(Class<? extends E> requestEntityClass) {
+    return response(requestEntityClass, requestEntityClass);
   }
 
   @Override
   public <E, R> Middleware<EntityResponseHandler<E, R>, SyncHandler<Response<ByteString>>>
-  response(Class<? extends E> entityClass, Class<? extends R> entityResponseClass) {
-    return inner -> withEntity(inner, entityClass)
-        .map(serialize(entityResponseClass));
+  response(Class<? extends E> requestEntityClass, Class<? extends R> responseEntityClass) {
+    return inner -> withEntity(inner, requestEntityClass)
+        .map(serialize(responseEntityClass));
   }
 
   @Override
   public <E> Middleware<EntityAsyncHandler<E, E>, AsyncHandler<Response<ByteString>>>
-  asyncDirect(Class<? extends E> entityClass) {
-    return asyncDirect(entityClass, entityClass);
+  asyncDirect(Class<? extends E> requestEntityClass) {
+    return asyncDirect(requestEntityClass, requestEntityClass);
   }
 
   @Override
   public <E, R> Middleware<EntityAsyncHandler<E, R>, AsyncHandler<Response<ByteString>>>
-  asyncDirect(Class<? extends E> entityClass, Class<? extends R> entityResponseClass) {
-    return inner -> withEntityAsync(inner.asResponseHandler(), entityClass)
-        .map(serialize(entityResponseClass));
+  asyncDirect(Class<? extends E> requestEntityClass, Class<? extends R> responseEntityClass) {
+    return inner -> withEntityAsync(inner.asResponseHandler(), requestEntityClass)
+        .map(serialize(responseEntityClass));
   }
 
   @Override
   public <E> Middleware<EntityAsyncResponseHandler<E, E>, AsyncHandler<Response<ByteString>>>
-  asyncResponse(Class<? extends E> entityClass) {
-    return asyncResponse(entityClass, entityClass);
+  asyncResponse(Class<? extends E> requestEntityClass) {
+    return asyncResponse(requestEntityClass, requestEntityClass);
   }
 
   @Override
   public <E, R> Middleware<EntityAsyncResponseHandler<E, R>, AsyncHandler<Response<ByteString>>>
-  asyncResponse(Class<? extends E> entityClass, Class<? extends R> entityResponseClass) {
-    return inner -> withEntityAsync(inner, entityClass)
-        .map(serialize(entityResponseClass));
+  asyncResponse(Class<? extends E> requestEntityClass, Class<? extends R> responseEntityClass) {
+    return inner -> withEntityAsync(inner, requestEntityClass)
+        .map(serialize(responseEntityClass));
   }
 
   private <E, R> SyncHandler<Response<R>> withEntity(

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityCodec.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityCodec.java
@@ -26,6 +26,8 @@ import java.io.IOException;
  */
 public interface EntityCodec {
 
+  String defaultContentType();
+
   <E> byte[] write(E entity, Class<? extends E> clazz) throws IOException;
 
   <E> E read(byte[] data, Class<? extends E> clazz) throws IOException;

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityCodec.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityCodec.java
@@ -1,0 +1,32 @@
+/*
+ * -\-\-
+ * Spotify Apollo Entity Middleware
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.entity;
+
+import java.io.IOException;
+
+/**
+ * Interface for serializing and de-serializing entity types.
+ */
+public interface EntityCodec {
+
+  <E> byte[] write(E entity, Class<? extends E> clazz) throws IOException;
+
+  <E> E read(byte[] data, Class<? extends E> clazz) throws IOException;
+}

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityCodec.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityCodec.java
@@ -21,6 +21,8 @@ package com.spotify.apollo.entity;
 
 import java.io.IOException;
 
+import okio.ByteString;
+
 /**
  * Interface for serializing and de-serializing entity types.
  */
@@ -28,7 +30,7 @@ public interface EntityCodec {
 
   String defaultContentType();
 
-  <E> byte[] write(E entity, Class<? extends E> clazz) throws IOException;
+  <E> ByteString write(E entity, Class<? extends E> clazz) throws IOException;
 
-  <E> E read(byte[] data, Class<? extends E> clazz) throws IOException;
+  <E> E read(ByteString data, Class<? extends E> clazz) throws IOException;
 }

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
@@ -43,11 +43,11 @@ public interface EntityMiddleware {
     return new CodecEntityMiddleware(codec, contentType);
   }
 
-  static EntityMiddleware jackson(ObjectMapper objectMapper) {
+  static EntityMiddleware forJackson(ObjectMapper objectMapper) {
     return new CodecEntityMiddleware(new JacksonEntityCodec(objectMapper));
   }
 
-  static EntityMiddleware jackson(ObjectMapper objectMapper, String contentType) {
+  static EntityMiddleware forJackson(ObjectMapper objectMapper, String contentType) {
     return new CodecEntityMiddleware(new JacksonEntityCodec(objectMapper), contentType);
   }
 

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
@@ -39,6 +39,10 @@ public interface EntityMiddleware {
     return new CodecEntityMiddleware(codec);
   }
 
+  static EntityMiddleware forCodec(EntityCodec codec, String contentType) {
+    return new CodecEntityMiddleware(codec, contentType);
+  }
+
   static EntityMiddleware jackson(ObjectMapper objectMapper) {
     return new CodecEntityMiddleware(new JacksonEntityCodec(objectMapper));
   }

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
@@ -1,0 +1,89 @@
+/*
+ * -\-\-
+ * Spotify Apollo Entity Middleware
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.entity;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.route.AsyncHandler;
+import com.spotify.apollo.route.Middleware;
+import com.spotify.apollo.route.SyncHandler;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import okio.ByteString;
+
+/**
+ * Apollo {@link Middleware}s for route handlers that work with a typed entity.
+ */
+public interface EntityMiddleware {
+
+  static EntityMiddleware forCodec(EntityCodec codec) {
+    return new CodecEntityMiddleware(codec);
+  }
+
+  static EntityMiddleware jackson(ObjectMapper objectMapper) {
+    return new CodecEntityMiddleware(new JacksonEntityCodec(objectMapper));
+  }
+
+  static EntityMiddleware jackson(ObjectMapper objectMapper, String contentType) {
+    return new CodecEntityMiddleware(new JacksonEntityCodec(objectMapper), contentType);
+  }
+
+  <E> Middleware<EntityHandler<E, ?>, SyncHandler<Response<ByteString>>>
+  direct(Class<? extends E> entityClass);
+
+  <E> Middleware<EntityResponseHandler<E, ?>, SyncHandler<Response<ByteString>>>
+  response(Class<? extends E> entityClass);
+
+  <E> Middleware<EntityAsyncHandler<E, ?>, AsyncHandler<Response<ByteString>>>
+  asyncDirect(Class<? extends E> entityClass);
+
+  <E> Middleware<EntityAsyncResponseHandler<E, ?>, AsyncHandler<Response<ByteString>>>
+  asyncResponse(Class<? extends E> entityClass);
+
+  <R> Middleware<SyncHandler<R>, SyncHandler<Response<ByteString>>>
+  serializerDirect(Class<? extends R> entityClass);
+
+  <R> Middleware<SyncHandler<Response<R>>, SyncHandler<Response<ByteString>>>
+  serializerResponse(Class<? extends R> entityClass);
+
+  <R> Middleware<AsyncHandler<R>, AsyncHandler<Response<ByteString>>>
+  asyncSerializerDirect(Class<? extends R> entityClass);
+
+  <R> Middleware<AsyncHandler<Response<R>>, AsyncHandler<Response<ByteString>>>
+  asyncSerializerResponse(Class<? extends R> entityClass);
+
+  interface EntityHandler<E, R>
+      extends SyncHandler<Function<? super E, ? extends R>> {
+  }
+
+  interface EntityResponseHandler<E, R>
+      extends SyncHandler<Function<? super E, ? extends Response<? extends R>>> {
+  }
+
+  interface EntityAsyncHandler<E, R>
+      extends SyncHandler<Function<? super E, ? extends CompletionStage<? extends R>>> {
+  }
+
+  interface EntityAsyncResponseHandler<E, R>
+      extends SyncHandler<Function<? super E, ? extends CompletionStage<? extends Response<? extends R>>>> {
+  }
+}

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
@@ -52,40 +52,40 @@ public interface EntityMiddleware {
   }
 
   <E> Middleware<EntityHandler<E, E>, SyncHandler<Response<ByteString>>>
-  direct(Class<? extends E> entityClass);
+  direct(Class<? extends E> requestEntityClass);
 
   <E, R> Middleware<EntityHandler<E, R>, SyncHandler<Response<ByteString>>>
-  direct(Class<? extends E> entityClass, Class<? extends R> entityResponseClass);
+  direct(Class<? extends E> requestEntityClass, Class<? extends R> responseEntityClass);
 
   <E> Middleware<EntityResponseHandler<E, E>, SyncHandler<Response<ByteString>>>
-  response(Class<? extends E> entityClass);
+  response(Class<? extends E> requestEntityClass);
 
   <E, R> Middleware<EntityResponseHandler<E, R>, SyncHandler<Response<ByteString>>>
-  response(Class<? extends E> entityClass, Class<? extends R> entityResponseClass);
+  response(Class<? extends E> requestEntityClass, Class<? extends R> responseEntityClass);
 
   <E> Middleware<EntityAsyncHandler<E, E>, AsyncHandler<Response<ByteString>>>
-  asyncDirect(Class<? extends E> entityClass);
+  asyncDirect(Class<? extends E> requestEntityClass);
 
   <E, R> Middleware<EntityAsyncHandler<E, R>, AsyncHandler<Response<ByteString>>>
-  asyncDirect(Class<? extends E> entityClass, Class<? extends R> entityResponseClass);
+  asyncDirect(Class<? extends E> requestEntityClass, Class<? extends R> responseEntityClass);
 
   <E> Middleware<EntityAsyncResponseHandler<E, E>, AsyncHandler<Response<ByteString>>>
-  asyncResponse(Class<? extends E> entityClass);
+  asyncResponse(Class<? extends E> requestEntityClass);
 
   <E, R> Middleware<EntityAsyncResponseHandler<E, R>, AsyncHandler<Response<ByteString>>>
-  asyncResponse(Class<? extends E> entityClass, Class<? extends R> entityResponseClass);
+  asyncResponse(Class<? extends E> requestEntityClass, Class<? extends R> responseEntityClass);
 
   <R> Middleware<SyncHandler<R>, SyncHandler<Response<ByteString>>>
-  serializerDirect(Class<? extends R> entityResponseClass);
+  serializerDirect(Class<? extends R> responseEntityClass);
 
   <R> Middleware<SyncHandler<Response<R>>, SyncHandler<Response<ByteString>>>
-  serializerResponse(Class<? extends R> entityResponseClass);
+  serializerResponse(Class<? extends R> responseEntityClass);
 
   <R> Middleware<AsyncHandler<R>, AsyncHandler<Response<ByteString>>>
-  asyncSerializerDirect(Class<? extends R> entityResponseClass);
+  asyncSerializerDirect(Class<? extends R> responseEntityClass);
 
   <R> Middleware<AsyncHandler<Response<R>>, AsyncHandler<Response<ByteString>>>
-  asyncSerializerResponse(Class<? extends R> entityResponseClass);
+  asyncSerializerResponse(Class<? extends R> responseEntityClass);
 
   interface EntityHandler<E, R>
       extends SyncHandler<Function<? super E, ? extends R>> {

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
@@ -19,7 +19,6 @@
  */
 package com.spotify.apollo.entity;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spotify.apollo.RequestContext;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.route.AsyncHandler;
@@ -42,14 +41,6 @@ public interface EntityMiddleware {
 
   static EntityMiddleware forCodec(EntityCodec codec, String contentType) {
     return new CodecEntityMiddleware(codec, contentType);
-  }
-
-  static EntityMiddleware forJackson(ObjectMapper objectMapper) {
-    return new CodecEntityMiddleware(new JacksonEntityCodec(objectMapper));
-  }
-
-  static EntityMiddleware forJackson(ObjectMapper objectMapper, String contentType) {
-    return new CodecEntityMiddleware(new JacksonEntityCodec(objectMapper), contentType);
   }
 
   <E> Middleware<EntityHandler<E, E>, SyncHandler<Response<ByteString>>>

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
@@ -76,30 +76,38 @@ public interface EntityMiddleware {
   asyncResponse(Class<? extends E> entityClass, Class<? extends R> entityResponseClass);
 
   <R> Middleware<SyncHandler<R>, SyncHandler<Response<ByteString>>>
-  serializerDirect(Class<? extends R> entityClass);
+  serializerDirect(Class<? extends R> entityResponseClass);
 
   <R> Middleware<SyncHandler<Response<R>>, SyncHandler<Response<ByteString>>>
-  serializerResponse(Class<? extends R> entityClass);
+  serializerResponse(Class<? extends R> entityResponseClass);
 
   <R> Middleware<AsyncHandler<R>, AsyncHandler<Response<ByteString>>>
-  asyncSerializerDirect(Class<? extends R> entityClass);
+  asyncSerializerDirect(Class<? extends R> entityResponseClass);
 
   <R> Middleware<AsyncHandler<Response<R>>, AsyncHandler<Response<ByteString>>>
-  asyncSerializerResponse(Class<? extends R> entityClass);
+  asyncSerializerResponse(Class<? extends R> entityResponseClass);
 
   interface EntityHandler<E, R>
       extends SyncHandler<Function<? super E, ? extends R>> {
+
+    default EntityResponseHandler<E, R> asResponseHandler() {
+      return rc -> e -> invoke(rc).andThen(Response::forPayload).apply(e);
+    }
   }
 
   interface EntityResponseHandler<E, R>
-      extends SyncHandler<Function<? super E, ? extends Response<? extends R>>> {
+      extends SyncHandler<Function<? super E, ? extends Response<R>>> {
   }
 
   interface EntityAsyncHandler<E, R>
-      extends SyncHandler<Function<? super E, ? extends CompletionStage<? extends R>>> {
+      extends SyncHandler<Function<? super E, ? extends CompletionStage<R>>> {
+
+    default EntityAsyncResponseHandler<E, R> asResponseHandler() {
+      return rc -> e -> invoke(rc).andThen(s -> s.thenApply(Response::forPayload)).apply(e);
+    }
   }
 
   interface EntityAsyncResponseHandler<E, R>
-      extends SyncHandler<Function<? super E, ? extends CompletionStage<? extends Response<? extends R>>>> {
+      extends SyncHandler<Function<? super E, ? extends CompletionStage<Response<R>>>> {
   }
 }

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/EntityMiddleware.java
@@ -51,17 +51,29 @@ public interface EntityMiddleware {
     return new CodecEntityMiddleware(new JacksonEntityCodec(objectMapper), contentType);
   }
 
-  <E> Middleware<EntityHandler<E, ?>, SyncHandler<Response<ByteString>>>
+  <E> Middleware<EntityHandler<E, E>, SyncHandler<Response<ByteString>>>
   direct(Class<? extends E> entityClass);
 
-  <E> Middleware<EntityResponseHandler<E, ?>, SyncHandler<Response<ByteString>>>
+  <E, R> Middleware<EntityHandler<E, R>, SyncHandler<Response<ByteString>>>
+  direct(Class<? extends E> entityClass, Class<? extends R> entityResponseClass);
+
+  <E> Middleware<EntityResponseHandler<E, E>, SyncHandler<Response<ByteString>>>
   response(Class<? extends E> entityClass);
 
-  <E> Middleware<EntityAsyncHandler<E, ?>, AsyncHandler<Response<ByteString>>>
+  <E, R> Middleware<EntityResponseHandler<E, R>, SyncHandler<Response<ByteString>>>
+  response(Class<? extends E> entityClass, Class<? extends R> entityResponseClass);
+
+  <E> Middleware<EntityAsyncHandler<E, E>, AsyncHandler<Response<ByteString>>>
   asyncDirect(Class<? extends E> entityClass);
 
-  <E> Middleware<EntityAsyncResponseHandler<E, ?>, AsyncHandler<Response<ByteString>>>
+  <E, R> Middleware<EntityAsyncHandler<E, R>, AsyncHandler<Response<ByteString>>>
+  asyncDirect(Class<? extends E> entityClass, Class<? extends R> entityResponseClass);
+
+  <E> Middleware<EntityAsyncResponseHandler<E, E>, AsyncHandler<Response<ByteString>>>
   asyncResponse(Class<? extends E> entityClass);
+
+  <E, R> Middleware<EntityAsyncResponseHandler<E, R>, AsyncHandler<Response<ByteString>>>
+  asyncResponse(Class<? extends E> entityClass, Class<? extends R> entityResponseClass);
 
   <R> Middleware<SyncHandler<R>, SyncHandler<Response<ByteString>>>
   serializerDirect(Class<? extends R> entityClass);

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/JacksonEntityCodec.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/JacksonEntityCodec.java
@@ -29,10 +29,17 @@ import java.util.Objects;
  */
 class JacksonEntityCodec implements EntityCodec {
 
+  private static final String DEFAULT_CONTENT_TYPE = "application/json";
+
   private final ObjectMapper objectMapper;
 
   JacksonEntityCodec(ObjectMapper objectMapper) {
     this.objectMapper = Objects.requireNonNull(objectMapper);
+  }
+
+  @Override
+  public String defaultContentType() {
+    return DEFAULT_CONTENT_TYPE;
   }
 
   @Override

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/JacksonEntityCodec.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/JacksonEntityCodec.java
@@ -29,14 +29,18 @@ import okio.ByteString;
 /**
  * Codec for writing and reading values using a Jackson {@link ObjectMapper}.
  */
-class JacksonEntityCodec implements EntityCodec {
+public class JacksonEntityCodec implements EntityCodec {
 
   private static final String DEFAULT_CONTENT_TYPE = "application/json";
 
   private final ObjectMapper objectMapper;
 
-  JacksonEntityCodec(ObjectMapper objectMapper) {
+  private JacksonEntityCodec(ObjectMapper objectMapper) {
     this.objectMapper = Objects.requireNonNull(objectMapper);
+  }
+
+  public static EntityCodec forMapper(ObjectMapper objectMapper) {
+    return new JacksonEntityCodec(objectMapper);
   }
 
   @Override

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/JacksonEntityCodec.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/JacksonEntityCodec.java
@@ -1,0 +1,47 @@
+/*
+ * -\-\-
+ * Spotify Apollo Entity Middleware
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.entity;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Codec for writing and reading values using a Jackson {@link ObjectMapper}.
+ */
+class JacksonEntityCodec implements EntityCodec {
+
+  private final ObjectMapper objectMapper;
+
+  JacksonEntityCodec(ObjectMapper objectMapper) {
+    this.objectMapper = Objects.requireNonNull(objectMapper);
+  }
+
+  @Override
+  public <E> byte[] write(E entity, Class<? extends E> clazz) throws IOException {
+    return objectMapper.writeValueAsBytes(entity);
+  }
+
+  @Override
+  public <E> E read(byte[] data, Class<? extends E> clazz) throws IOException {
+    return objectMapper.readValue(data, clazz);
+  }
+}

--- a/apollo-entity/src/main/java/com/spotify/apollo/entity/JacksonEntityCodec.java
+++ b/apollo-entity/src/main/java/com/spotify/apollo/entity/JacksonEntityCodec.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Objects;
 
+import okio.ByteString;
+
 /**
  * Codec for writing and reading values using a Jackson {@link ObjectMapper}.
  */
@@ -43,12 +45,12 @@ class JacksonEntityCodec implements EntityCodec {
   }
 
   @Override
-  public <E> byte[] write(E entity, Class<? extends E> clazz) throws IOException {
-    return objectMapper.writeValueAsBytes(entity);
+  public <E> ByteString write(E entity, Class<? extends E> clazz) throws IOException {
+    return ByteString.of(objectMapper.writeValueAsBytes(entity));
   }
 
   @Override
-  public <E> E read(byte[] data, Class<? extends E> clazz) throws IOException {
-    return objectMapper.readValue(data, clazz);
+  public <E> E read(ByteString data, Class<? extends E> clazz) throws IOException {
+    return objectMapper.readValue(data.toByteArray(), clazz);
   }
 }

--- a/apollo-entity/src/test/java/com/spotify/apollo/entity/EntityCodecsTest.java
+++ b/apollo-entity/src/test/java/com/spotify/apollo/entity/EntityCodecsTest.java
@@ -60,7 +60,7 @@ public class EntityCodecsTest {
 
   @Test
   public void testWithCustomJacksonMapper() throws Exception {
-    EntityMiddleware e = EntityMiddleware.jackson(OBJECT_MAPPER);
+    EntityMiddleware e = EntityMiddleware.forJackson(OBJECT_MAPPER);
 
     ServiceHelper service = ServiceHelper.create(entityApp(e), "entity-test");
     service.start();
@@ -75,7 +75,7 @@ public class EntityCodecsTest {
 
   @Test
   public void testWithCustomContentType() throws Exception {
-    EntityMiddleware e = EntityMiddleware.jackson(
+    EntityMiddleware e = EntityMiddleware.forJackson(
         OBJECT_MAPPER, "application/vnd+spotify.test+json");
 
     ServiceHelper service =ServiceHelper.create(entityApp(e), "entity-test");

--- a/apollo-entity/src/test/java/com/spotify/apollo/entity/EntityCodecsTest.java
+++ b/apollo-entity/src/test/java/com/spotify/apollo/entity/EntityCodecsTest.java
@@ -158,22 +158,22 @@ public class EntityCodecsTest {
     }
 
     @Override
-    public <E> byte[] write(E entity, Class<? extends E> clazz) throws IOException {
+    public <E> ByteString write(E entity, Class<? extends E> clazz) throws IOException {
       if (!String.class.equals(clazz)) {
         throw new UnsupportedOperationException("Can only encode strings");
       }
 
-      return ((String) entity).getBytes();
+      return ByteString.encodeUtf8((String) entity);
     }
 
     @Override
-    public <E> E read(byte[] data, Class<? extends E> clazz) throws IOException {
+    public <E> E read(ByteString data, Class<? extends E> clazz) throws IOException {
       if (!String.class.equals(clazz)) {
         throw new UnsupportedOperationException("Can only encode strings");
       }
 
       //noinspection unchecked
-      return (E) new String(data);
+      return (E) data.utf8();
     }
   }
 }

--- a/apollo-entity/src/test/java/com/spotify/apollo/entity/EntityCodecsTest.java
+++ b/apollo-entity/src/test/java/com/spotify/apollo/entity/EntityCodecsTest.java
@@ -60,7 +60,7 @@ public class EntityCodecsTest {
 
   @Test
   public void testWithCustomJacksonMapper() throws Exception {
-    EntityMiddleware e = EntityMiddleware.forJackson(OBJECT_MAPPER);
+    EntityMiddleware e = EntityMiddleware.forCodec(JacksonEntityCodec.forMapper(OBJECT_MAPPER));
 
     ServiceHelper service = ServiceHelper.create(entityApp(e), "entity-test");
     service.start();
@@ -75,8 +75,9 @@ public class EntityCodecsTest {
 
   @Test
   public void testWithCustomContentType() throws Exception {
-    EntityMiddleware e = EntityMiddleware.forJackson(
-        OBJECT_MAPPER, "application/vnd+spotify.test+json");
+    EntityMiddleware e = EntityMiddleware.forCodec(
+        JacksonEntityCodec.forMapper(OBJECT_MAPPER),
+        "application/vnd+spotify.test+json");
 
     ServiceHelper service =ServiceHelper.create(entityApp(e), "entity-test");
     service.start();

--- a/apollo-entity/src/test/java/com/spotify/apollo/entity/EntityMiddlewareTest.java
+++ b/apollo-entity/src/test/java/com/spotify/apollo/entity/EntityMiddlewareTest.java
@@ -316,10 +316,10 @@ public final class EntityMiddlewareTest {
 
     Stream<Route<AsyncHandler<Response<ByteString>>>> syncRoutes = Stream.of(
         Route.with(e.direct(Person.class), "POST", DIRECT, rc -> app::personDirect),
-        Route.with(e.direct(Person.class), "POST", DIRECT_O, rc -> app::personOther),
+        Route.with(e.direct(Person.class, Group.class), "POST", DIRECT_O, rc -> app::personOther),
         Route.with(e.response(Person.class), "POST", RESPONSE, rc -> app::personResponse),
-        Route.with(e.response(Person.class), "POST", RESPONSE_O, rx -> app::personOtherResponse),
-        Route.with(e.response(Person.class), "POST", RESPONSE_E, rx -> app::personEmptyResponse),
+        Route.with(e.response(Person.class, Group.class), "POST", RESPONSE_O, rc -> app::personOtherResponse),
+        Route.with(e.response(Person.class, Void.class), "POST", RESPONSE_E, rc -> app::personEmptyResponse),
         Route.with(e.serializerDirect(Person.class), "GET", GET_DIRECT, rc -> app.getPerson()),
         Route.with(e.serializerResponse(Person.class), "GET", GET_RESPONSE, rc -> app.getPersonResponse()),
         Route.with(e.serializerDirect(Unserializable.class), "GET", UNSERIALIZABLE, rc -> app.getUnserializable())
@@ -327,10 +327,10 @@ public final class EntityMiddlewareTest {
 
     Stream<Route<AsyncHandler<Response<ByteString>>>> asyncRoutes = Stream.of(
         Route.with(e.asyncDirect(Person.class), "POST", DIRECT + "-async", rc -> app::personAsync),
-        Route.with(e.asyncDirect(Person.class), "POST", DIRECT_O + "-async", rc -> app::personAsyncOther),
+        Route.with(e.asyncDirect(Person.class, Group.class), "POST", DIRECT_O + "-async", rc -> app::personAsyncOther),
         Route.with(e.asyncResponse(Person.class), "POST", RESPONSE + "-async", rc -> app::personAsyncResponse),
-        Route.with(e.asyncResponse(Person.class), "POST", RESPONSE_O + "-async", rc -> app::personAsyncOtherResponse),
-        Route.with(e.asyncResponse(Person.class), "POST", RESPONSE_E + "-async", rc -> app::personAsyncEmptyResponse),
+        Route.with(e.asyncResponse(Person.class, Group.class), "POST", RESPONSE_O + "-async", rc -> app::personAsyncOtherResponse),
+        Route.with(e.asyncResponse(Person.class, Void.class), "POST", RESPONSE_E + "-async", rc -> app::personAsyncEmptyResponse),
         Route.with(e.asyncSerializerDirect(Person.class), "GET", GET_DIRECT + "-async", rc -> app.getPersonAsync()),
         Route.with(e.asyncSerializerResponse(Person.class), "GET", GET_RESPONSE + "-async", rc -> app.getPersonResponseAsync()),
         Route.with(e.asyncSerializerDirect(Unserializable.class), "GET", UNSERIALIZABLE + "-async", rc -> app.getUnserializableAsync())

--- a/apollo-entity/src/test/java/com/spotify/apollo/entity/EntityMiddlewareTest.java
+++ b/apollo-entity/src/test/java/com/spotify/apollo/entity/EntityMiddlewareTest.java
@@ -312,7 +312,7 @@ public final class EntityMiddlewareTest {
    */
   static void init(Environment environment) {
     EntityMiddlewareTest app = new EntityMiddlewareTest();
-    EntityMiddleware e = EntityMiddleware.forJackson(OBJECT_MAPPER);
+    EntityMiddleware e = EntityMiddleware.forCodec(JacksonEntityCodec.forMapper(OBJECT_MAPPER));
 
     Stream<Route<AsyncHandler<Response<ByteString>>>> syncRoutes = Stream.of(
         Route.with(e.direct(Person.class), "POST", DIRECT, rc -> app::personDirect),

--- a/apollo-entity/src/test/java/com/spotify/apollo/entity/EntityMiddlewareTest.java
+++ b/apollo-entity/src/test/java/com/spotify/apollo/entity/EntityMiddlewareTest.java
@@ -312,7 +312,7 @@ public final class EntityMiddlewareTest {
    */
   static void init(Environment environment) {
     EntityMiddlewareTest app = new EntityMiddlewareTest();
-    EntityMiddleware e = EntityMiddleware.jackson(OBJECT_MAPPER);
+    EntityMiddleware e = EntityMiddleware.forJackson(OBJECT_MAPPER);
 
     Stream<Route<AsyncHandler<Response<ByteString>>>> syncRoutes = Stream.of(
         Route.with(e.direct(Person.class), "POST", DIRECT, rc -> app::personDirect),

--- a/apollo-entity/src/test/java/com/spotify/apollo/entity/EntityMiddlewareTest.java
+++ b/apollo-entity/src/test/java/com/spotify/apollo/entity/EntityMiddlewareTest.java
@@ -1,0 +1,507 @@
+/*
+ * -\-\-
+ * Spotify Apollo Entity Middleware
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.entity;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.apollo.Environment;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.Status;
+import com.spotify.apollo.route.AsyncHandler;
+import com.spotify.apollo.route.Middleware;
+import com.spotify.apollo.route.Route;
+import com.spotify.apollo.test.ServiceHelper;
+
+import org.hamcrest.Matcher;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import io.norberg.automatter.AutoMatter;
+import io.norberg.automatter.jackson.AutoMatterModule;
+import okio.ByteString;
+
+import static com.spotify.apollo.entity.JsonMatchers.asStr;
+import static com.spotify.apollo.entity.JsonMatchers.hasJsonPath;
+import static com.spotify.apollo.test.unit.ResponseMatchers.doesNotHaveHeader;
+import static com.spotify.apollo.test.unit.ResponseMatchers.hasHeader;
+import static com.spotify.apollo.test.unit.ResponseMatchers.hasNoPayload;
+import static com.spotify.apollo.test.unit.ResponseMatchers.hasPayload;
+import static com.spotify.apollo.test.unit.ResponseMatchers.hasStatus;
+import static com.spotify.apollo.test.unit.StatusTypeMatchers.withCode;
+import static com.spotify.apollo.test.unit.StatusTypeMatchers.withReasonPhrase;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
+public final class EntityMiddlewareTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+      .registerModule(new AutoMatterModule());
+
+  private static final ByteString PERSON_JSON = ByteString.encodeUtf8(
+      "{\"name\":\"rouz\"}");
+
+  private static final ByteString BAD_JSON = ByteString.encodeUtf8(
+      "I am not Jayson");
+
+  private static final String DIRECT = "/direct";
+  private static final String DIRECT_O = "/direct-o";
+  private static final String RESPONSE = "/response";
+  private static final String RESPONSE_O = "/response-o";
+  private static final String RESPONSE_E = "/response-e";
+  private static final String GET_DIRECT = "/person";
+  private static final String GET_RESPONSE = "/person-resp";
+  private static final String UNSERIALIZABLE = "/unserializable";
+
+  @ClassRule
+  public static ServiceHelper serviceHelper =
+      ServiceHelper.create(EntityMiddlewareTest::init, "entity-test");
+
+  @Test
+  public void testDirectPerson() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("POST", DIRECT, PERSON_JSON));
+
+    assertThat(resp, hasStatus(withCode(Status.OK)));
+    assertThat(resp, hasHeader("Content-Type", equalTo("application/json")));
+    assertThat(resp, hasPayload(asStr(hasJsonPath("name", equalTo("hello rouz")))));
+  }
+
+  @Test
+  public void testDirectOther() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("POST", DIRECT_O, PERSON_JSON));
+
+    assertThat(resp, hasStatus(withCode(Status.OK)));
+    assertThat(resp, hasHeader("Content-Type", equalTo("application/json")));
+    assertThat(resp, hasPayload(asStr(hasJsonPath("people[0].name", equalTo("rouz")))));
+  }
+
+  @Test
+  public void testResponse() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("POST", RESPONSE, PERSON_JSON));
+
+    assertThat(resp, hasStatus(withCode(Status.ACCEPTED)));
+    assertThat(resp, hasHeader("Content-Type", equalTo("application/json")));
+    assertThat(resp, hasHeader("Name-Length", equalTo("4")));
+    assertThat(resp, hasPayload(asStr(hasJsonPath("name", equalTo("rouz-resp")))));
+  }
+
+  @Test
+  public void testResponseOther() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("POST", RESPONSE_O, PERSON_JSON));
+
+    assertThat(resp, hasStatus(withCode(Status.ACCEPTED)));
+    assertThat(resp, hasStatus(withReasonPhrase(equalTo("was rouz"))));
+    assertThat(resp, hasHeader("Content-Type", equalTo("application/json")));
+    assertThat(resp, hasPayload(asStr(hasJsonPath("people[0].name", equalTo("rouz")))));
+  }
+
+  @Test
+  public void testResponseEmpty() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("POST", RESPONSE_E, PERSON_JSON));
+
+    assertThat(resp, hasStatus(withCode(Status.ACCEPTED)));
+    assertThat(resp, hasStatus(withReasonPhrase(equalTo("was rouz"))));
+    assertThat(resp, doesNotHaveHeader("Content-Type"));
+    assertThat(resp, hasNoPayload());
+  }
+
+  @Test
+  public void testGetPerson() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("GET", GET_DIRECT));
+
+    assertThat(resp, hasStatus(withCode(Status.OK)));
+    assertThat(resp, hasHeader("Content-Type", equalTo("application/json")));
+    assertThat(resp, hasPayload(asStr(hasJsonPath("name", equalTo("static")))));
+  }
+
+  @Test
+  public void testGetPersonResponse() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("GET", GET_RESPONSE));
+
+    assertThat(resp, hasStatus(withCode(Status.OK)));
+    assertThat(resp, hasHeader("Content-Type", equalTo("application/json")));
+    assertThat(resp, hasHeader("Reflection", equalTo("in-use")));
+    assertThat(resp, hasPayload(asStr(hasJsonPath("name", equalTo("static-resp")))));
+  }
+
+  @Test
+  public void testDirectAsync() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("POST", DIRECT + "-async", PERSON_JSON));
+
+    assertThat(resp, hasStatus(withCode(Status.OK)));
+    assertThat(resp, hasHeader("Content-Type", equalTo("application/json")));
+    assertThat(resp, hasPayload(asStr(hasJsonPath("name", equalTo("hello rouz")))));
+  }
+
+  @Test
+  public void testDirectAsyncOther() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("POST", DIRECT_O + "-async", PERSON_JSON));
+
+    assertThat(resp, hasStatus(withCode(Status.OK)));
+    assertThat(resp, hasHeader("Content-Type", equalTo("application/json")));
+    assertThat(resp, hasPayload(asStr(hasJsonPath("people[0].name", equalTo("rouz")))));
+  }
+
+  @Test
+  public void testResponseAsync() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("POST", RESPONSE + "-async", PERSON_JSON));
+
+    assertThat(resp, hasStatus(withCode(Status.ACCEPTED)));
+    assertThat(resp, hasHeader("Content-Type", equalTo("application/json")));
+    assertThat(resp, hasHeader("Async", equalTo("true")));
+    assertThat(resp, hasPayload(asStr(hasJsonPath("name", equalTo("hello rouz")))));
+  }
+
+  @Test
+  public void testResponseAsyncOther() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("POST", RESPONSE_O + "-async", PERSON_JSON));
+
+    assertThat(resp, hasStatus(withCode(Status.ACCEPTED)));
+    assertThat(resp, hasHeader("Async", equalTo("true")));
+    assertThat(resp, hasHeader("Content-Type", equalTo("application/json")));
+    assertThat(resp, hasPayload(asStr(hasJsonPath("people[0].name", equalTo("rouz")))));
+  }
+
+  @Test
+  public void testResponseAsyncEmpty() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("POST", RESPONSE_E + "-async", PERSON_JSON));
+
+    assertThat(resp, hasStatus(withCode(Status.ACCEPTED)));
+    assertThat(resp, hasHeader("Async", equalTo("true")));
+    assertThat(resp, doesNotHaveHeader("Content-Type"));
+    assertThat(resp, hasNoPayload());
+  }
+
+  @Test
+  public void testGetAsyncPerson() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("GET", GET_DIRECT + "-async"));
+
+    assertThat(resp, hasStatus(withCode(Status.OK)));
+    assertThat(resp, hasHeader("Content-Type", equalTo("application/json")));
+    assertThat(resp, hasPayload(asStr(hasJsonPath("name", equalTo("static-async")))));
+  }
+
+  @Test
+  public void testGetAsyncPersonResponse() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("GET", GET_RESPONSE + "-async"));
+
+    assertThat(resp, hasStatus(withCode(Status.OK)));
+    assertThat(resp, hasHeader("Content-Type", equalTo("application/json")));
+    assertThat(resp, hasHeader("Async", equalTo("true")));
+    assertThat(resp, hasHeader("Reflection", equalTo("in-use")));
+    assertThat(resp, hasPayload(asStr(hasJsonPath("name", equalTo("static-resp-async")))));
+  }
+
+  @Test
+  public void testMissingPayloadDirect() throws Exception {
+    Response<ByteString> resp = await(serviceHelper.request("POST", DIRECT));
+    assertBadRequest(resp, equalTo("Missing payload"));
+  }
+
+  @Test
+  public void testMissingPayloadDirectAsync() throws Exception {
+    Response<ByteString> resp = await(serviceHelper.request("POST", DIRECT + "-async"));
+    assertBadRequest(resp, equalTo("Missing payload"));
+  }
+
+  @Test
+  public void testMissingPayloadResponse() throws Exception {
+    Response<ByteString> resp = await(serviceHelper.request("POST", RESPONSE));
+    assertBadRequest(resp, equalTo("Missing payload"));
+  }
+
+  @Test
+  public void testMissingPayloadResponseAsync() throws Exception {
+    Response<ByteString> resp = await(serviceHelper.request("POST", RESPONSE + "-async"));
+    assertBadRequest(resp, equalTo("Missing payload"));
+  }
+
+  @Test
+  public void testBadPayloadDirect() throws Exception {
+    Response<ByteString> resp = await(serviceHelper.request("POST", DIRECT, BAD_JSON));
+    assertBadRequest(resp, startsWith("Payload parsing failed"));
+  }
+
+  @Test
+  public void testBadPayloadDirectAsync() throws Exception {
+    Response<ByteString> resp = await(serviceHelper.request("POST", DIRECT + "-async", BAD_JSON));
+    assertBadRequest(resp, startsWith("Payload parsing failed"));
+  }
+
+  @Test
+  public void testBadPayloadResponse() throws Exception {
+    Response<ByteString> resp = await(serviceHelper.request("POST", RESPONSE, BAD_JSON));
+    assertBadRequest(resp, startsWith("Payload parsing failed"));
+  }
+
+  @Test
+  public void testBadPayloadResponseAsync() throws Exception {
+    Response<ByteString> resp = await(serviceHelper.request("POST", RESPONSE + "-async", BAD_JSON));
+    assertBadRequest(resp, startsWith("Payload parsing failed"));
+  }
+
+  void assertBadRequest(Response<ByteString> resp, Matcher<String> reasonPhraseMatcher) {
+    assertThat(resp, hasStatus(withCode(Status.BAD_REQUEST)));
+    assertThat(resp, hasStatus(withReasonPhrase(reasonPhraseMatcher)));
+    assertThat(resp, doesNotHaveHeader("Content-Type"));
+    assertThat(resp, hasNoPayload());
+  }
+
+  @Test
+  public void testBadResponse() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("GET", UNSERIALIZABLE));
+
+    assertThat(resp, hasStatus(withCode(Status.INTERNAL_SERVER_ERROR)));
+    assertThat(resp, hasStatus(withReasonPhrase(startsWith("Payload serialization failed"))));
+    assertThat(resp, doesNotHaveHeader("Content-Type"));
+    assertThat(resp, hasNoPayload());
+  }
+
+  @Test
+  public void testBadResponseAsync() throws Exception {
+    Response<ByteString> resp =
+        await(serviceHelper.request("GET", UNSERIALIZABLE + "-async"));
+
+    assertThat(resp, hasStatus(withCode(Status.INTERNAL_SERVER_ERROR)));
+    assertThat(resp, hasStatus(withReasonPhrase(startsWith("Payload serialization failed"))));
+    assertThat(resp, doesNotHaveHeader("Content-Type"));
+    assertThat(resp, hasNoPayload());
+  }
+
+  /**
+   * Entity based API used in tests
+   */
+  static void init(Environment environment) {
+    EntityMiddlewareTest app = new EntityMiddlewareTest();
+    EntityMiddleware e = EntityMiddleware.jackson(OBJECT_MAPPER);
+
+    Stream<Route<AsyncHandler<Response<ByteString>>>> syncRoutes = Stream.of(
+        Route.with(e.direct(Person.class), "POST", DIRECT, rc -> app::personDirect),
+        Route.with(e.direct(Person.class), "POST", DIRECT_O, rc -> app::personOther),
+        Route.with(e.response(Person.class), "POST", RESPONSE, rc -> app::personResponse),
+        Route.with(e.response(Person.class), "POST", RESPONSE_O, rx -> app::personOtherResponse),
+        Route.with(e.response(Person.class), "POST", RESPONSE_E, rx -> app::personEmptyResponse),
+        Route.with(e.serializerDirect(Person.class), "GET", GET_DIRECT, rc -> app.getPerson()),
+        Route.with(e.serializerResponse(Person.class), "GET", GET_RESPONSE, rc -> app.getPersonResponse()),
+        Route.with(e.serializerDirect(Unserializable.class), "GET", UNSERIALIZABLE, rc -> app.getUnserializable())
+    ).map(r -> r.withMiddleware(Middleware::syncToAsync));
+
+    Stream<Route<AsyncHandler<Response<ByteString>>>> asyncRoutes = Stream.of(
+        Route.with(e.asyncDirect(Person.class), "POST", DIRECT + "-async", rc -> app::personAsync),
+        Route.with(e.asyncDirect(Person.class), "POST", DIRECT_O + "-async", rc -> app::personAsyncOther),
+        Route.with(e.asyncResponse(Person.class), "POST", RESPONSE + "-async", rc -> app::personAsyncResponse),
+        Route.with(e.asyncResponse(Person.class), "POST", RESPONSE_O + "-async", rc -> app::personAsyncOtherResponse),
+        Route.with(e.asyncResponse(Person.class), "POST", RESPONSE_E + "-async", rc -> app::personAsyncEmptyResponse),
+        Route.with(e.asyncSerializerDirect(Person.class), "GET", GET_DIRECT + "-async", rc -> app.getPersonAsync()),
+        Route.with(e.asyncSerializerResponse(Person.class), "GET", GET_RESPONSE + "-async", rc -> app.getPersonResponseAsync()),
+        Route.with(e.asyncSerializerDirect(Unserializable.class), "GET", UNSERIALIZABLE + "-async", rc -> app.getUnserializableAsync())
+    );
+
+    environment.routingEngine()
+        .registerRoutes(syncRoutes)
+        .registerRoutes(asyncRoutes)
+    ;
+  }
+
+  @AutoMatter
+  public interface Person {
+    String name();
+  }
+
+  @AutoMatter
+  public interface Group {
+    List<Person> people();
+  }
+
+  /**
+   * Handler returning the entity type directly
+   */
+  Person personDirect(Person p) {
+    return new PersonBuilder()
+        .name("hello " + p.name())
+        .build();
+  }
+
+  /**
+   * Handler returning a some other entity directly
+   */
+  Group personOther(Person p) {
+    return new GroupBuilder()
+        .people(p)
+        .build();
+  }
+
+  /**
+   * Handler returning a response containing the entity type
+   */
+  Response<Person> personResponse(Person p) {
+    Person p2 = PersonBuilder.from(p)
+        .name(p.name() + "-resp")
+        .build();
+
+    return Response.of(Status.ACCEPTED, p2)
+        .withHeader("Name-Length", Integer.toString(p.name().length()));
+  }
+
+  /**
+   * Handler returning a response containing some other entity
+   */
+  Response<Group> personOtherResponse(Person p) {
+    return Response.forStatus(Status.ACCEPTED.withReasonPhrase("was " + p.name()))
+        .withPayload(new GroupBuilder()
+                         .people(p)
+                         .build());
+  }
+
+  /**
+   * Handler returning a response with no entity
+   */
+  Response<Void> personEmptyResponse(Person p) {
+    return Response.forStatus(Status.ACCEPTED.withReasonPhrase("was " + p.name()));
+  }
+
+  /**
+   * Handler that only returns an entity
+   */
+  Person getPerson() {
+    return new PersonBuilder()
+        .name("static")
+        .build();
+  }
+
+  /**
+   * Handler that returns an entity in a response
+   */
+  Response<Person> getPersonResponse() {
+    return Response.forPayload(
+        new PersonBuilder()
+            .name("static-resp")
+            .build())
+        .withHeader("Reflection", "in-use");
+  }
+
+  /**
+   * Async handler returning an entity in a response
+   */
+  CompletionStage<Person> personAsync(Person p) {
+    return completedFuture(personDirect(p));
+  }
+
+  /**
+   * Async handler returning another entity in the response
+   */
+  CompletionStage<Group> personAsyncOther(Person p) {
+    return completedFuture(personOther(p));
+  }
+
+  /**
+   * Async handler returning an entity in a response
+   */
+  CompletionStage<Response<Person>> personAsyncResponse(Person p) {
+    return completedFuture(
+        Response.of(Status.ACCEPTED, personDirect(p))
+            .withHeader("Async", "true"));
+  }
+
+  /**
+   * Async handler returning a response with other entity
+   */
+  CompletionStage<Response<Group>> personAsyncOtherResponse(Person p) {
+    return completedFuture(
+        Response.of(Status.ACCEPTED, personOther(p))
+            .withHeader("Async", "true"));
+  }
+
+  /**
+   * Async handler returning a response with no entity
+   */
+  CompletionStage<Response<Void>> personAsyncEmptyResponse(Person p) {
+    return completedFuture(
+        Response.<Void>forStatus(Status.ACCEPTED)
+            .withHeader("Async", "true"));
+  }
+
+  /**
+   * Async handler that only returns an entity
+   */
+  CompletionStage<Person> getPersonAsync() {
+    return completedFuture(
+        new PersonBuilder()
+            .name("static-async")
+            .build());
+  }
+
+  /**
+   * Async handler that returns an entity in a response
+   */
+  CompletionStage<Response<Person>> getPersonResponseAsync() {
+    return completedFuture(
+        Response.forPayload(
+            new PersonBuilder()
+                .name("static-resp-async")
+                .build())
+            .withHeader("Async", "true")
+            .withHeader("Reflection", "in-use"));
+  }
+
+  /**
+   * Handler returning an unserializable entity
+   */
+  Unserializable getUnserializable() {
+    return new Unserializable() {};
+  }
+
+  /**
+   * Async handler returning an unserializable entity
+   */
+  CompletionStage<Unserializable> getUnserializableAsync() {
+    return completedFuture(new Unserializable() {});
+  }
+
+  static Response<ByteString> await(CompletionStage<Response<ByteString>> resp)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return resp.toCompletableFuture().get(5, TimeUnit.SECONDS);
+  }
+
+  interface Unserializable {
+  }
+}

--- a/apollo-entity/src/test/java/com/spotify/apollo/entity/JacksonEntityCodecTest.java
+++ b/apollo-entity/src/test/java/com/spotify/apollo/entity/JacksonEntityCodecTest.java
@@ -1,0 +1,105 @@
+/*
+ * -\-\-
+ * Spotify Apollo Entity Middleware
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.entity;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.apollo.AppInit;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.Status;
+import com.spotify.apollo.route.Middleware;
+import com.spotify.apollo.route.Route;
+import com.spotify.apollo.test.ServiceHelper;
+
+import org.junit.Test;
+
+import io.norberg.automatter.AutoMatter;
+import io.norberg.automatter.jackson.AutoMatterModule;
+import okio.ByteString;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES;
+import static com.spotify.apollo.entity.EntityMiddlewareTest.await;
+import static com.spotify.apollo.entity.JsonMatchers.asStr;
+import static com.spotify.apollo.entity.JsonMatchers.hasJsonPath;
+import static com.spotify.apollo.test.unit.ResponseMatchers.hasHeader;
+import static com.spotify.apollo.test.unit.ResponseMatchers.hasPayload;
+import static com.spotify.apollo.test.unit.ResponseMatchers.hasStatus;
+import static com.spotify.apollo.test.unit.StatusTypeMatchers.withCode;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class JacksonEntityCodecTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+      .setPropertyNamingStrategy(CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+      .registerModule(new AutoMatterModule());
+
+  private static final ByteString JSON = ByteString.encodeUtf8(
+      "{\"naming_convention_used\":\"for this value\"}");
+
+  @Test
+  public void testWithCustomMapper() throws Exception {
+    EntityMiddleware e = EntityMiddleware.jackson(OBJECT_MAPPER);
+
+    ServiceHelper service = ServiceHelper.create(app(e), "entity-test");
+    service.start();
+
+    Response<ByteString> resp = await(service.request("GET", "/", JSON));
+    assertThat(resp, hasStatus(withCode(Status.OK)));
+    assertThat(resp, hasHeader("Content-Type", equalTo("application/json")));
+    assertThat(resp, hasPayload(asStr(hasJsonPath("naming_convention_used", equalTo("override")))));
+
+    service.close();
+  }
+
+  @Test
+  public void testWithCustomContentType() throws Exception {
+    EntityMiddleware e = EntityMiddleware.jackson(
+        OBJECT_MAPPER, "application/vnd+spotify.test+json");
+
+    ServiceHelper service =ServiceHelper.create(app(e), "entity-test");
+    service.start();
+
+    Response<ByteString> resp = await(service.request("GET", "/", JSON));
+    assertThat(resp, hasStatus(withCode(Status.OK)));
+    assertThat(resp, hasHeader("Content-Type", equalTo("application/vnd+spotify.test+json")));
+    assertThat(resp, hasPayload(asStr(hasJsonPath("naming_convention_used", equalTo("override")))));
+
+    service.close();
+  }
+
+  private AppInit app(EntityMiddleware e) {
+    return env -> env.routingEngine()
+        .registerRoute(
+            Route.with(e.direct(Entity.class), "GET", "/", rc -> this::endpoint)
+                .withMiddleware(Middleware::syncToAsync));
+  }
+
+  Entity endpoint(Entity entity) {
+    assertThat(entity.namingConventionUsed(), equalTo("for this value"));
+    return EntityBuilder.from(entity)
+        .namingConventionUsed("override")
+        .build();
+  }
+
+  @AutoMatter
+  interface Entity {
+    String namingConventionUsed();
+  }
+}

--- a/apollo-entity/src/test/java/com/spotify/apollo/entity/JsonMatchers.java
+++ b/apollo-entity/src/test/java/com/spotify/apollo/entity/JsonMatchers.java
@@ -1,0 +1,72 @@
+/*
+ * -\-\-
+ * Spotify Apollo Entity Middleware
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.entity;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import okio.ByteString;
+
+import static com.jayway.jsonassert.JsonAssert.with;
+
+class JsonMatchers {
+
+  static Matcher<ByteString> asStr(Matcher<String> strMatcher) {
+    return new TypeSafeMatcher<ByteString>() {
+      @Override
+      protected boolean matchesSafely(ByteString byteString) {
+        return strMatcher.matches(byteString.utf8());
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        strMatcher.describeTo(description);
+      }
+    };
+  }
+
+  static <T> Matcher<String> hasJsonPath(String jsonPath, Matcher<T> matches) {
+
+    return new TypeSafeMatcher<String>() {
+      @Override
+      protected boolean matchesSafely(String json) {
+        try {
+          with(json).assertThat(jsonPath, matches);
+          return true;
+        } catch (AssertionError ae) {
+          return false;
+        } catch (Exception e) {
+          return false;
+        }
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description
+            .appendText(" JSON object with a value at node ")
+            .appendValue(jsonPath)
+            .appendText(" that is ")
+            .appendDescriptionOf(matches);
+      }
+    };
+  }
+
+}

--- a/apollo-entity/src/test/resources/logback.xml
+++ b/apollo-entity/src/test/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration debug="false">
+    <root level="INFO">
+        <appender class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+    </root>
+
+    <logger name="com.spotify.apollo.entity.CodecEntityMiddleware" level="OFF"/>
+</configuration>

--- a/apollo-http-service/README.md
+++ b/apollo-http-service/README.md
@@ -1,6 +1,8 @@
 Apollo HTTP Service
 ===================
 
+[![Maven Central](https://img.shields.io/maven-central/v/com.spotify/apollo-parent.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.spotify%22%20apollo*)
+
 The `apollo-http-service` library is a small bundle of Apollo modules. It incorporates both
 [apollo-api](../apollo-api) and [apollo-core](../apollo-core) and ties them together with the
 [jetty-http-server](../modules/jetty-http-server) and the [okhttp-client](../modules/okhttp-client)
@@ -82,6 +84,8 @@ http.server.port = ${?HTTP_PORT}
 
 For more information on how to manage configuration, see [Apollo Core](../apollo-core) and the [Typesafe Config](https://github.com/typesafehub/config) documentation.
 
+### Maven
+
 `./pom.xml`
 ```xml
 <project>
@@ -101,7 +105,7 @@ For more information on how to manage configuration, see [Apollo Core](../apollo
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-bom</artifactId>
-                <version>1.0.0</version>
+                <version>1.0.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <module>apollo-route</module>
         <module>apollo-test</module>
         <module>apollo-extra</module>
+        <module>apollo-entity</module>
         <module>apollo-http-service</module>
 
         <module>modules/slack</module>


### PR DESCRIPTION
A set of middleware for working with typed route handlers.

---

The gist of it

```java
class MyApplication {

  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();

  static void init(Environment environment) {
    MyApplication app = new MyApplication();
    EntityMiddleware entity = EntityMiddleware.forCodec(JacksonEntityCodec.forMapper(OBJECT_MAPPER));

    Route<SyncHandler<Response<ByteString>>> route = Route.with(
        entity.direct(Person.class),
        "PUT", "/person/<id>",
        rc -> person -> app.updatePerson(rc.pathArgs().get("id"), person));

    // ...
  }

  Person updatePerson(String id, Person person) {
    // ...
  }
}
```

There's also support for other handler signatures. See README in PR.