### PR TITLE
Fix typo in code example

### DIFF
--- a/apollo-api/docs/app-init-environment.md
+++ b/apollo-api/docs/app-init-environment.md
@@ -37,7 +37,7 @@ public class DataService {
 
     environment.closer().register(cassandraClusterConnection);
 
-    RouteProvider addressResource = new AddressResource(responseText);
+    RouteProvider addressResource = new AddressResource(cassandraClusterConnection);
     environment.routingEngine().registerAutoRoutes(addressResource);
   }
 


### PR DESCRIPTION
Provide cassandraClusterConnection as argument to the AddressResource constructor
instead of nonexistent responseText variable