### PR TITLE
Update example to match updated Response

### DIFF
--- a/apollo-test/README.md
+++ b/apollo-test/README.md
@@ -106,7 +106,7 @@ public class MinimalAppTest {
     CompletionStage<Response<ByteString>> replyFuture = serviceHelper.request("GET", "/beer");
 
     StatusType statusCode = replyFuture.toCompletableFuture().get().getStatusCode();
-    assertThat(statusCode.statusCode(), is(Status.INTERNAL_SERVER_ERROR.statusCode()));
+    assertThat(statusCode.status(), is(Status.INTERNAL_SERVER_ERROR));
   }
 }
 ```


### PR DESCRIPTION
Replace Response.statusCode(), which seems to have vanished, with Response.status() in README.md example