### PR TITLE
Remove instance executors

### DIFF
--- a/apollo-core/src/main/java/com/spotify/apollo/core/Service.java
+++ b/apollo-core/src/main/java/com/spotify/apollo/core/Service.java
@@ -22,8 +22,6 @@ package com.spotify.apollo.core;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closer;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 
 import com.spotify.apollo.module.ApolloModule;
 import com.typesafe.config.Config;
@@ -195,27 +193,6 @@ public interface Service {
      * @return The configuration for this service instance.
      */
     Config getConfig();
-
-    /**
-     * Returns a shared {@link com.google.common.util.concurrent.ListeningExecutorService} that has
-     * virtually infinite capacity and that can be used for long-running jobs.  This executor is
-     * scoped along with the service instance, which avoids the need to use the very problematic
-     * daemon threads.
-     *
-     * @return A shared {@link com.google.common.util.concurrent.ListeningExecutorService}.
-     */
-    ListeningExecutorService getExecutorService();
-
-    /**
-     * Returns a shared {@link com.google.common.util.concurrent.ListeningScheduledExecutorService}
-     * that has capacity appropriate for scheduled jobs, i.e. jobs that run periodically and have a
-     * limited execution time.  Use {@link #getExecutorService()} for jobs that run forever.  This
-     * executor is scoped along with the service instance, which avoids the need to use the very
-     * problematic daemon threads.
-     *
-     * @return A shared {@link com.google.common.util.concurrent.ListeningScheduledExecutorService}.
-     */
-    ListeningScheduledExecutorService getScheduledExecutorService();
 
     /**
      * Returns a {@link com.google.common.io.Closer} for convenience, where you can register {@link

--- a/apollo-extra/README.md
+++ b/apollo-extra/README.md
@@ -14,6 +14,12 @@ Defines a couple of utilities that make it easier to move between `ListenableFut
         .thenApply(message -> Response.forPayload(message.data()));
 ```
 
+Also defines the 
+[`ExecutorServiceCloser`](src/main/java/com/spotify/apollo/concurrent/ExecutorServiceCloser.java) 
+utility, which makes it convenient to register application-specific
+`ExecutorService` instances with the Apollo `Closer` for lifecycle 
+management.
+
 ## com.spotify.apollo.route
 
 Contains some serializer middlewares, and utilities for versioning endpoints.

--- a/apollo-extra/pom.xml
+++ b/apollo-extra/pom.xml
@@ -67,6 +67,11 @@
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apollo-extra/src/main/java/com/spotify/apollo/concurrent/ExecutorServiceCloser.java
+++ b/apollo-extra/src/main/java/com/spotify/apollo/concurrent/ExecutorServiceCloser.java
@@ -1,0 +1,128 @@
+/*
+ * -\-\-
+ * Spotify Apollo Extra
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.concurrent;
+
+import com.spotify.apollo.Environment;
+
+import java.io.Closeable;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+/**
+ * A utility class to make it easier to get the {@link com.google.common.io.Closer} returned by
+ * {@link Environment#closer()} to handle shutting down {@link ExecutorService} instances.
+ */
+// optional is useful as a field and parameter type in this class
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+public class ExecutorServiceCloser implements Closeable {
+
+  private final ExecutorService executorService;
+  private final Optional<Duration> timeout;
+
+  private ExecutorServiceCloser(ExecutorService executorService, Optional<Duration> timeout) {
+    this.executorService = requireNonNull(executorService);
+    this.timeout = requireNonNull(timeout);
+
+    timeout
+        .ifPresent(duration -> checkArgument(!duration.isNegative(), "Timeout must be positive"));
+  }
+
+  /**
+   * Returns a new ExecutorServiceCloser for the same executor service as this, but with
+   * a timeout specied by the {@code timeout} parameter.
+   */
+  public ExecutorServiceCloser withTimeout(Duration timeout) {
+    return new ExecutorServiceCloser(executorService, Optional.of(timeout));
+  }
+
+  /**
+   * Create an ExecutorServiceCloser for the supplied ExecutorService. This closer will not have
+   * an associated timeout.
+   */
+  public static ExecutorServiceCloser of(ExecutorService executorService) {
+    return new ExecutorServiceCloser(executorService, Optional.empty());
+  }
+
+  /**
+   * Shuts down the associated ExecutorService using the {@link ExecutorService#shutdown()}
+   * method. If the closer has a configured timeout, it will wait for the ExecutorService to
+   * complete executing its current tasks, or until the timeout expires. If the timeout expires,
+   * a {@link WaitTimedOutException} will be thrown.
+   *
+   * This method is idempotent; repeated invocations have no effect.
+   *
+   * @throws WaitTimedOutException if a timeout is configured and the executor service doesn't
+   *                               finish shutting down before the timeout expires.
+   */
+  @Override
+  public void close() throws WaitTimedOutException {
+    executorService.shutdown();
+
+    timeout.ifPresent(
+        timeout -> {
+          if (!awaitTerminationUninterruptibly(timeout)) {
+            throw new WaitTimedOutException(timeout);
+          }
+        }
+    );
+  }
+
+  private boolean awaitTerminationUninterruptibly(Duration timeout) {
+    // this implementation stolen with pride from Guava's Uninterruptibles class.
+    boolean interrupted = false;
+    try {
+      long remainingNanos = timeout.toNanos();
+      long end = System.nanoTime() + remainingNanos;
+
+      // the difference compared to the Uninterruptibles implementations is this condition:
+      // since there are many ExecutorService implementations, I don't want to rely on how they
+      // deal with negative timeouts in the awaitTermination method.
+      while (remainingNanos > 0) {
+        try {
+          return executorService.awaitTermination(remainingNanos, NANOSECONDS);
+        } catch (InterruptedException e) {
+          interrupted = true;
+          remainingNanos = end - System.nanoTime();
+        }
+      }
+
+      return false;
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /**
+   * Thrown if a configured wait timeout has expired before the executor service was shut down.
+   */
+  public static class WaitTimedOutException extends RuntimeException {
+
+    public WaitTimedOutException(Duration timeout) {
+      super("wait timed out after " + timeout);
+    }
+  }
+}

--- a/apollo-extra/src/test/java/com/spotify/apollo/concurrent/ExecutorServiceCloserTest.java
+++ b/apollo-extra/src/test/java/com/spotify/apollo/concurrent/ExecutorServiceCloserTest.java
@@ -1,0 +1,142 @@
+/*
+ * -\-\-
+ * Spotify Apollo Extra
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.concurrent;
+
+import com.google.common.base.Stopwatch;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertThat;
+
+public class ExecutorServiceCloserTest {
+
+  private ExecutorServiceCloser closer;
+
+  private ExecutorService service ;
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void setUp() throws Exception {
+    service = Executors.newSingleThreadExecutor();
+
+    closer = ExecutorServiceCloser.of(service);
+  }
+
+  @Test
+  public void shouldShutdownTheExecutorOnClose() throws Exception {
+    closer.close();
+
+    assertThat(service.isShutdown(), is(true));
+  }
+
+  @Test
+  public void shouldBeSafeToInvokeMultipleTimes() throws Exception {
+    closer.close();
+    closer.close();
+
+    assertThat(service.isShutdown(), is(true));
+  }
+
+  @Test(timeout = 1000)
+  public void shouldNotWaitIfNotConfiguredTo() throws Exception {
+    service.execute(() -> {
+      try {
+        Thread.sleep(2000L);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    closer.close();
+  }
+
+  @Test
+  public void shouldWaitIfConfiguredTo() throws Exception {
+    service.execute(() -> {
+      try {
+        Thread.sleep(2000L);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    closer.withTimeout(Duration.ofMillis(3000L)).close();
+
+    assertThat(stopwatch.elapsed(TimeUnit.MILLISECONDS), greaterThan(1000L));
+  }
+
+  @Test
+  public void shouldThrowExceptionIfConfiguredWaitTimesOut() throws Exception {
+    service.execute(() -> {
+      try {
+        Thread.sleep(2000L);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    thrown.expect(ExecutorServiceCloser.WaitTimedOutException.class);
+    closer.withTimeout(Duration.ofMillis(500L)).close();
+  }
+
+  @Test
+  public void shouldNotBeInterruptibleWhenAwaitingTermination() throws Exception {
+    service.execute(() -> {
+      try {
+        Thread.sleep(1000L);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    Thread t = new Thread(() -> {
+      try {
+        closer.withTimeout(Duration.ofMillis(2000)).close();
+      } catch (ExecutorServiceCloser.WaitTimedOutException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    t.start();
+
+    // give the thread some time to start executing the closer
+    Thread.sleep(100);
+    t.interrupt();
+
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    t.join();
+
+    // validate that we waited something like the full 1000 ms required for the task to finish
+    assertThat(stopwatch.elapsed(TimeUnit.MILLISECONDS), greaterThan(500L));
+  }
+}


### PR DESCRIPTION
The idea is that executors are easy to provide at the application level, if needed, and that the ones provided by Apollo are very rarely used in practice. So it's a feature of Apollo that doesn't carry its weight.

This PR also does some minor cleanup of the ServiceImpl class.