### PR TITLE
Add new StubClient methods for defining request mappings

### DIFF
--- a/apollo-test/src/main/java/com/spotify/apollo/test/StubClient.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/StubClient.java
@@ -259,7 +259,11 @@ public class StubClient implements Client, Closeable {
 
   /**
    * Immutable response builder.
+   *
+   * @deprecated in favour of using the {@link #addMapping(Matcher, Response)} or
+   * {@link #addMapping(Matcher, ResponseSource)} methods.
    */
+  @Deprecated
   public class StubbedResponseBuilder {
     @Nullable
     private final ResponseWithDelay responseWithDelay;

--- a/apollo-test/src/main/java/com/spotify/apollo/test/StubClient.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/StubClient.java
@@ -114,7 +114,7 @@ public class StubClient implements Client, Closeable {
    * be invoked for each request that matches the supplied Matcher.
    */
   private void mapRequestToResponses(Matcher<Request> requestMatcher, ResponseSource responses) {
-    mappings.add(MatcherResponseSourcePair.create(requestMatcher, responses));
+    mappings.add(new MatcherResponseSourcePair(requestMatcher, responses));
   }
 
   /**
@@ -122,7 +122,7 @@ public class StubClient implements Client, Closeable {
    * to responses.
    */
   private void addMatcherFirst(Matcher<Request> requestMatcher, ResponseSource responses) {
-    mappings.addFirst(MatcherResponseSourcePair.create(requestMatcher, responses));
+    mappings.addFirst(new MatcherResponseSourcePair(requestMatcher, responses));
   }
 
   @Override
@@ -145,8 +145,8 @@ public class StubClient implements Client, Closeable {
    */
   private ResponseSource responseSource(Request request) {
     for (MatcherResponseSourcePair entry : mappings) {
-      if (entry.requestMatcher().matches(request)) {
-        return entry.responseSource();
+      if (entry.requestMatcher.matches(request)) {
+        return entry.responseSource;
       }
     }
     return null;
@@ -354,13 +354,14 @@ public class StubClient implements Client, Closeable {
     }
   }
 
-  @AutoValue
-  static abstract class MatcherResponseSourcePair {
-    public abstract Matcher<Request> requestMatcher();
-    public abstract ResponseSource responseSource();
+  private static class MatcherResponseSourcePair {
+    private final Matcher<Request> requestMatcher;
+    private final ResponseSource responseSource;
 
-    public static MatcherResponseSourcePair create(Matcher<Request> requestMatcher, ResponseSource responseSource) {
-      return new AutoValue_StubClient_MatcherResponseSourcePair(requestMatcher, responseSource);
+    private MatcherResponseSourcePair(Matcher<Request> requestMatcher,
+                                      ResponseSource responseSource) {
+      this.requestMatcher = requestMatcher;
+      this.responseSource = responseSource;
     }
   }
 }

--- a/apollo-test/src/main/java/com/spotify/apollo/test/StubClient.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/StubClient.java
@@ -345,7 +345,7 @@ public class StubClient implements Client, Closeable {
   }
 
   @AutoValue
-  static abstract class RequestResponsePair {
+  public static abstract class RequestResponsePair {
     public abstract Request request();
     public abstract Response<ByteString> response();
 

--- a/apollo-test/src/main/java/com/spotify/apollo/test/response/ResponseWithDelay.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/response/ResponseWithDelay.java
@@ -21,6 +21,7 @@ package com.spotify.apollo.test.response;
 
 import com.spotify.apollo.Response;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import okio.ByteString;
@@ -37,6 +38,10 @@ public class ResponseWithDelay {
   public static ResponseWithDelay forResponse(
       Response<ByteString> response, long delay, TimeUnit unit) {
     return new ResponseWithDelay(response, unit.toMillis(delay));
+  }
+
+  public static ResponseWithDelay forResponse(Response<ByteString> response, Duration delay) {
+    return new ResponseWithDelay(response, delay.toMillis());
   }
 
   private ResponseWithDelay(Response<ByteString> response, long delayMillis) {

--- a/apollo-test/src/main/java/com/spotify/apollo/test/response/ResponseWithDelay.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/response/ResponseWithDelay.java
@@ -21,7 +21,6 @@ package com.spotify.apollo.test.response;
 
 import com.spotify.apollo.Response;
 
-import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import okio.ByteString;
@@ -38,10 +37,6 @@ public class ResponseWithDelay {
   public static ResponseWithDelay forResponse(
       Response<ByteString> response, long delay, TimeUnit unit) {
     return new ResponseWithDelay(response, unit.toMillis(delay));
-  }
-
-  public static ResponseWithDelay forResponse(Response<ByteString> response, Duration delay) {
-    return new ResponseWithDelay(response, delay.toMillis());
   }
 
   private ResponseWithDelay(Response<ByteString> response, long delayMillis) {


### PR DESCRIPTION
Fixes #62

The rationale for adding new methods and deprecating the old, while retaining their behaviour is that changing the behaviour seems to potentially cause unnecessary upgrading pain.

The rationale for not including the ability to specify a duration for delaying the response in the new methods is that it's not a very common use case, and specifying the delay is easy through the ```Responses``` class.