### PR TITLE
Final(?) metrics touches

### DIFF
--- a/modules/metrics/TODO.txt
+++ b/modules/metrics/TODO.txt
@@ -1,10 +1,9 @@
-- Add metrics filtering
-- Create decorator ordering
-- Update documentation
-- Go through and fix TODO comments
+- Create decorator ordering - only for 2.0.0
 
 
 DONE:
+- Update documentation
+- Add metrics filtering
 - Create metric for request sizes
 - Create metric for reply sizes
 - Wire up into HttpService

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsModule.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsModule.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Named;
@@ -98,7 +99,8 @@ public class MetricsModule extends AbstractApolloModule {
   public MetricsFactory apolloMetrics(SemanticMetricRegistry metricRegistry,
                                       MetricsConfig metricsConfig) {
     return new SemanticMetricsFactory(metricRegistry,
-                                      what -> metricsConfig.serverMetrics().contains(what));
+                                      what -> metricsConfig.serverMetrics().contains(what),
+                                      metricsConfig.precreateCodes());
   }
 
   @Provides @Singleton

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/MetricsConfig.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/MetricsConfig.java
@@ -21,7 +21,9 @@ package com.spotify.apollo.metrics.semantic;
 
 import com.typesafe.config.Config;
 
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -44,6 +46,7 @@ public class MetricsConfig {
           ERROR_RATIO);
 
   private final Set<What> enabledMetrics;
+  private final Set<Integer> precreateCodes;
 
   @Inject
   MetricsConfig(Config config) {
@@ -51,6 +54,12 @@ public class MetricsConfig {
       enabledMetrics = parseConfig(config.getStringList("metrics.server"));
     } else {
       enabledMetrics = DEFAULT_ENABLED_METRICS;
+    }
+
+    if (config.hasPath("metrics.precreate-codes")) {
+      precreateCodes = new HashSet<>(config.getIntList("metrics.precreate-codes"));
+    } else {
+      precreateCodes = Collections.emptySet();
     }
   }
 
@@ -66,5 +75,9 @@ public class MetricsConfig {
 
   public Set<What> serverMetrics() {
     return enabledMetrics;
+  }
+
+  public Set<Integer> precreateCodes() {
+    return precreateCodes;
   }
 }

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/SemanticMetricsFactory.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/SemanticMetricsFactory.java
@@ -32,17 +32,20 @@ public class SemanticMetricsFactory implements MetricsFactory {
   private final SemanticMetricRegistry metricRegistry;
   private final MetricId metricId;
   private final Predicate<What> enabledMetrics;
+  private final Set<Integer> precreateCodes;
 
   public SemanticMetricsFactory(final SemanticMetricRegistry metricRegistry,
-                                Predicate<What> enabledMetrics) {
+                                Predicate<What> enabledMetrics,
+                                Set<Integer> precreateCodes) {
     this.metricRegistry = metricRegistry;
     this.metricId = MetricId.build();
     this.enabledMetrics = enabledMetrics;
+    this.precreateCodes = precreateCodes;
   }
 
   @Override
   public ServiceMetrics createForService(String serviceName) {
     final MetricId id = metricId.tagged("service", serviceName);
-    return new SemanticServiceMetrics(metricRegistry, id, enabledMetrics);
+    return new SemanticServiceMetrics(metricRegistry, id, precreateCodes, enabledMetrics);
   }
 }

--- a/modules/metrics/src/test/java/com/spotify/apollo/metrics/semantic/MetricsConfigTest.java
+++ b/modules/metrics/src/test/java/com/spotify/apollo/metrics/semantic/MetricsConfigTest.java
@@ -26,6 +26,8 @@ import org.junit.Test;
 
 import java.util.EnumSet;
 
+import autovalue.shaded.com.google.common.common.collect.Sets;
+
 import static com.spotify.apollo.metrics.semantic.What.ENDPOINT_REQUEST_DURATION;
 import static com.spotify.apollo.metrics.semantic.What.ENDPOINT_REQUEST_RATE;
 import static com.spotify.apollo.metrics.semantic.What.REQUEST_PAYLOAD_SIZE;
@@ -47,5 +49,14 @@ public class MetricsConfigTest {
 
     assertThat(new MetricsConfig(config).serverMetrics(),
                is(EnumSet.of(REQUEST_PAYLOAD_SIZE, ENDPOINT_REQUEST_DURATION, ENDPOINT_REQUEST_RATE)));
+  }
+
+  @Test
+  public void shouldEnablePrecreatingMetersForStatusCodesIfConfigured() throws Exception {
+    Config config = ConfigFactory.parseString(
+        "metrics.precreate-codes: [300, 403, 404]");
+
+    assertThat(Sets.newHashSet(new MetricsConfig(config).precreateCodes()),
+               is(Sets.newHashSet(300, 403, 404)));
   }
 }


### PR DESCRIPTION
Adds the last couple of things I want to include in 1.x:

- support for pre-creating request-rate meters
- documentation updates