### PR TITLE
set provided scope for auto-value dependency

### DIFF
--- a/apollo-test/pom.xml
+++ b/apollo-test/pom.xml
@@ -44,6 +44,7 @@
         <dependency>
             <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
This prevents users of apollo-test from having auto-value pulled into
their project as a compile-scope dependency.

Fixes #121.