### PR TITLE
Have okhttp-client propagate headers from from apollo Request

### DIFF
--- a/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClient.java
+++ b/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClient.java
@@ -21,6 +21,7 @@ package com.spotify.apollo.http.client;
 
 import com.spotify.apollo.environment.IncomingRequestAwareClient;
 
+import com.squareup.okhttp.Headers;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
@@ -74,6 +75,7 @@ class HttpClient implements IncomingRequestAwareClient {
     final Request request = new Request.Builder()
         .method(apolloRequest.method(), requestBody.orElse(null))
         .url(apolloRequest.uri())
+        .headers(Headers.of(apolloRequest.headers().asMap()))
         .build();
 
     final CompletableFuture<com.spotify.apollo.Response<ByteString>> result =


### PR DESCRIPTION
Headers from the Apollo Request object would previously not propagate to the remote endpoint when doing http requests utilising the okhttp-client module. This change, with test case, makes sure that the headers propagate from the Apollo Request object to the okhttp equivalent.