### PR TITLE
Add Route#withDocString(DocString)

### DIFF
--- a/apollo-api/src/main/java/com/spotify/apollo/route/Route.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/route/Route.java
@@ -60,6 +60,11 @@ public interface Route<H> {
         method(), uri(), handler(), doc(summary, description));
   }
 
+  default Route<H> withDocString(DocString doc) {
+    return copy(
+        method(), uri(), handler(), doc);
+  }
+
   default <K> Route<K> withMiddleware(Middleware<? super H, ? extends K> middleware) {
     return copy(
         method(), uri(), middleware.apply(handler()), docString().orElse(null));

--- a/apollo-api/src/test/java/com/spotify/apollo/route/RouteTest.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/route/RouteTest.java
@@ -20,9 +20,12 @@
 package com.spotify.apollo.route;
 
 import com.spotify.apollo.RequestContext;
+import com.spotify.apollo.route.Route.DocString;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -44,5 +47,14 @@ public class RouteTest {
 
     String actual = route.handler().invoke(requestContext).toCompletableFuture().get();
     assertThat(actual, equalTo("this is the best response"));
+  }
+
+  @Test
+  public void shouldSupportSupplyingDocStringValueType() throws Exception {
+    Route<AsyncHandler<String>> route =
+        Route.sync("GET", "/foo", requestContext -> "this is the best response")
+            .withDocString(DocString.doc("summary", "description"));
+
+    assertThat(route.docString(), equalTo(Optional.of(DocString.doc("summary", "description"))));
   }
 }


### PR DESCRIPTION
Better API when loading documentation from bundled resources, or
partially generating doc strings from e.g. Protobuf payload descriptors.