### PR TITLE
Dont use executor in StubClient if delay <= 0

### DIFF
--- a/apollo-test/src/main/java/com/spotify/apollo/test/StubClient.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/StubClient.java
@@ -104,7 +104,12 @@ public class StubClient implements Client, Closeable {
       requestsAndResponses.add(RequestResponsePair.create(request, response));
       future.complete(response);
     };
-    executor.schedule(replyTask, responseWithDelay.getDelayMillis(), TimeUnit.MILLISECONDS);
+
+    if (responseWithDelay.getDelayMillis() <= 0) {
+      replyTask.run();
+    } else {
+      executor.schedule(replyTask, responseWithDelay.getDelayMillis(), TimeUnit.MILLISECONDS);
+    }
 
     return future;
   }


### PR DESCRIPTION
It is useful for tests to have few threads to be more
deterministic. There is no reason to schedule responses
on an executor if the delay <= 0