### PR TITLE
Close down okhttp dispatcher executor

### DIFF
--- a/modules/jetty-http-server/pom.xml
+++ b/modules/jetty-http-server/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>com.squareup.okhttp</groupId>
             <artifactId>okhttp</artifactId>
-            <version>2.5.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/okhttp-client/pom.xml
+++ b/modules/okhttp-client/pom.xml
@@ -46,6 +46,10 @@
             <groupId>com.squareup.okhttp</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.spotify</groupId>
+            <artifactId>apollo-extra</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/OkHttpClientProviderTest.java
+++ b/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/OkHttpClientProviderTest.java
@@ -19,6 +19,8 @@
  */
 package com.spotify.apollo.http.client;
 
+import com.google.common.io.Closer;
+
 import com.squareup.okhttp.OkHttpClient;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -31,7 +33,8 @@ public class OkHttpClientProviderTest {
 
   private static OkHttpClient buildClient(final String str) {
     final Config config = ConfigFactory.parseString(str);
-    final OkHttpClientProvider provider = new OkHttpClientProvider(config);
+    final Closer closer = Closer.create();
+    final OkHttpClientProvider provider = new OkHttpClientProvider(config, closer);
     return provider.get();
   }
 


### PR DESCRIPTION
This seems to be the way one should close the okhttp client according to: https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/OkHttpClient.java#L90-L100

I've tested this with a CLI that earlier would hang the JVM for about 30 seconds before actually exiting. Looking at the threads, I saw that one non-deamon thread called `Dispatcher` was not stopped.