### PR TITLE
Fix Content-Type utf-8 header

### DIFF
--- a/apollo-extra/src/main/java/com/spotify/apollo/route/HtmlSerializerMiddlewares.java
+++ b/apollo-extra/src/main/java/com/spotify/apollo/route/HtmlSerializerMiddlewares.java
@@ -40,7 +40,7 @@ import okio.ByteString;
 public class HtmlSerializerMiddlewares {
 
   private static final String CONTENT_TYPE = "Content-Type";
-  private static final String HTML = "text/html; charset=UTF8";
+  private static final String HTML = "text/html; charset=utf-8";
 
   private static final Configuration configuration = new Configuration(Configuration.VERSION_2_3_22);
 

--- a/apollo-extra/src/main/java/com/spotify/apollo/route/JsonSerializerMiddlewares.java
+++ b/apollo-extra/src/main/java/com/spotify/apollo/route/JsonSerializerMiddlewares.java
@@ -33,7 +33,7 @@ public class JsonSerializerMiddlewares {
   }
 
   private static final String CONTENT_TYPE = "Content-Type";
-  private static final String JSON = "application/json; charset=UTF8";
+  private static final String JSON = "application/json; charset=utf-8";
 
   private static <T> ByteString serialize(ObjectWriter objectWriter, T object) {
     try {

--- a/apollo-extra/src/test/java/com/spotify/apollo/route/HtmlSerializerMiddlewaresTest.java
+++ b/apollo-extra/src/test/java/com/spotify/apollo/route/HtmlSerializerMiddlewaresTest.java
@@ -85,7 +85,7 @@ public class HtmlSerializerMiddlewaresTest {
 
   private void checkContentTypeAndBody(final Response<ByteString> response) {
     assertEquals("<html>yo</html>\n", response.payload().get().utf8());
-    assertThat(response.headers().get("Content-Type"), is(Optional.of("text/html; charset=UTF8")));
+    assertThat(response.headers().get("Content-Type"), is(Optional.of("text/html; charset=utf-8")));
   }
 
 }

--- a/apollo-extra/src/test/java/com/spotify/apollo/route/JsonSerializerMiddlewaresTest.java
+++ b/apollo-extra/src/test/java/com/spotify/apollo/route/JsonSerializerMiddlewaresTest.java
@@ -48,7 +48,7 @@ public class JsonSerializerMiddlewaresTest {
 
   private static void checkContentType(Response<ByteString> response) {
     assertThat(response.headers().get("Content-Type"),
-               is(Optional.of("application/json; charset=UTF8")));
+               is(Optional.of("application/json; charset=utf-8")));
   }
 
   @Test


### PR DESCRIPTION
Should say "utf-8" instead of "UTF8" based on [W3C](https://www.w3.org/International/articles/http-charset/index)