### PR TITLE
Improve Jetty HTTP Server error handling

### DIFF
--- a/modules/jetty-http-server/README.md
+++ b/modules/jetty-http-server/README.md
@@ -9,11 +9,6 @@ key | type | required | note
 `http.server.port` | int | optional | ie 8080
 `http.server.address` | string | optional | default 0.0.0.0
 `http.server.ttlMillis` | int | optional | default 30000, determines how long before an error response is sent
-`http.server.keepAliveTimeout` | int | optional | default 300
-`http.server.workerThreads` | int | optional | default max(availableProcessors/4, 2)
-`http.server.maxHttpChunkLength` | int | optional | default 128 * 1024
-
-_todo_ implement all config keys
 
 ## Special request headers
 

--- a/modules/jetty-http-server/README.md
+++ b/modules/jetty-http-server/README.md
@@ -8,12 +8,10 @@ key | type | required | note
 --- | --- | --- | --- 
 `http.server.port` | int | optional | ie 8080
 `http.server.address` | string | optional | default 0.0.0.0
-`http.server.registrationName` | string | optional | default global service name
 `http.server.ttlMillis` | int | optional | default 30000, determines how long before an error response is sent
 `http.server.keepAliveTimeout` | int | optional | default 300
 `http.server.workerThreads` | int | optional | default max(availableProcessors/4, 2)
 `http.server.maxHttpChunkLength` | int | optional | default 128 * 1024
-`http.server.useFirstPathSegmentAsAuthority` | boolean | optional | default false
 
 _todo_ implement all config keys
 

--- a/modules/jetty-http-server/README.md
+++ b/modules/jetty-http-server/README.md
@@ -9,7 +9,7 @@ key | type | required | note
 `http.server.port` | int | optional | ie 8080
 `http.server.address` | string | optional | default 0.0.0.0
 `http.server.registrationName` | string | optional | default global service name
-`http.server.ttlMillis` | int | optional | default 30000
+`http.server.ttlMillis` | int | optional | default 30000, determines how long before an error response is sent
 `http.server.keepAliveTimeout` | int | optional | default 300
 `http.server.workerThreads` | int | optional | default max(availableProcessors/4, 2)
 `http.server.maxHttpChunkLength` | int | optional | default 128 * 1024

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerConfig.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerConfig.java
@@ -19,13 +19,10 @@
  */
 package com.spotify.apollo.http.server;
 
-import com.spotify.apollo.core.Services;
 import com.typesafe.config.Config;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 
-import static com.spotify.apollo.environment.ConfigUtil.optionalBoolean;
 import static com.spotify.apollo.environment.ConfigUtil.optionalInt;
 import static com.spotify.apollo.environment.ConfigUtil.optionalString;
 
@@ -39,12 +36,10 @@ class HttpServerConfig {
   private static final int DEFAULT_KEEP_ALIVE_TIMEOUT = 300; // SECONDS
   private static final int DEFAULT_MAX_HTTP_CHUNK_LENGTH = 128 * 1024; // 128 kB
 
-  private final String serviceName;
   private final Config config;
 
   @Inject
-  HttpServerConfig(@Named(Services.INJECT_SERVICE_NAME) String serviceName, Config config) {
-    this.serviceName = serviceName;
+  HttpServerConfig(Config config) {
     this.config = config;
   }
 
@@ -54,10 +49,6 @@ class HttpServerConfig {
 
   public Integer port() {
     return optionalInt(config, CONFIG_BASE_NAME + ".port").orElse(null);
-  }
-
-  public String registrationName() {
-    return optionalString(config, CONFIG_BASE_NAME + ".registrationName").orElse(serviceName);
   }
 
   public long ttlMillis() {
@@ -74,9 +65,5 @@ class HttpServerConfig {
 
   public int maxHttpChunkLength() {
     return optionalInt(config, CONFIG_BASE_NAME + ".maxHttpChunkLength").orElse(DEFAULT_MAX_HTTP_CHUNK_LENGTH);
-  }
-
-  public boolean useFirstPathSegmentAsAuthority() {
-    return optionalBoolean(config, CONFIG_BASE_NAME + ".useFirstPathSegmentAsAuthority").orElse(false);
   }
 }

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerConfig.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerConfig.java
@@ -31,10 +31,6 @@ class HttpServerConfig {
   private static final String CONFIG_BASE_NAME = "http.server";
   private static final String DEFAULT_HTTP_ADDRESS = "0.0.0.0";
   private static final int DEFAULT_TTL_MILLIS = 30000;
-  private static final int DEFAULT_WORKER_THREADS =
-      Math.max(Runtime.getRuntime().availableProcessors()/4, 2);
-  private static final int DEFAULT_KEEP_ALIVE_TIMEOUT = 300; // SECONDS
-  private static final int DEFAULT_MAX_HTTP_CHUNK_LENGTH = 128 * 1024; // 128 kB
 
   private final Config config;
 
@@ -53,17 +49,5 @@ class HttpServerConfig {
 
   public long ttlMillis() {
     return optionalInt(config, CONFIG_BASE_NAME + ".ttlMillis").orElse(DEFAULT_TTL_MILLIS);
-  }
-
-  public int keepAliveTimeout() {
-    return optionalInt(config, CONFIG_BASE_NAME + ".keepAliveTimeout").orElse(DEFAULT_KEEP_ALIVE_TIMEOUT);
-  }
-
-  public int workerThreads() {
-    return optionalInt(config, CONFIG_BASE_NAME + ".workerThreads").orElse(DEFAULT_WORKER_THREADS);
-  }
-
-  public int maxHttpChunkLength() {
-    return optionalInt(config, CONFIG_BASE_NAME + ".maxHttpChunkLength").orElse(DEFAULT_MAX_HTTP_CHUNK_LENGTH);
   }
 }

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerImpl.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerImpl.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 
 /**
  * A fully configured server that can be started and stopped.
@@ -60,10 +61,11 @@ class HttpServerImpl implements HttpServer {
         ServerInfos.create(SERVER_ID, serverSocketAddress);
 
     server = new Server(serverSocketAddress);
-    server.setHandler(new ApolloRequestHandler(serverInfo, requestHandler));
+    server.setHandler(new ApolloRequestHandler(serverInfo, requestHandler,
+                                               Duration.ofMillis(config.ttlMillis())));
     try {
       server.start();
-      closer.register(this::close);
+      closer.register(this);
     } catch (Exception e) {
       throw new RuntimeException("Failed to start server", e);
     }

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/TimeoutListener.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/TimeoutListener.java
@@ -1,0 +1,62 @@
+/*
+ * -\-\-
+ * Spotify Apollo Jetty HTTP Server Module
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.http.server;
+
+import java.io.IOException;
+
+import javax.servlet.AsyncEvent;
+import javax.servlet.AsyncListener;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Handles timeouts sent by Jetty, ensuring we send a response.
+ */
+final class TimeoutListener implements AsyncListener {
+  private static final TimeoutListener INSTANCE = new TimeoutListener();
+
+  private TimeoutListener() {
+    // prevent instantiation from outside class
+  }
+
+  @Override
+  public void onComplete(AsyncEvent event) throws IOException {
+    // empty
+  }
+
+  @Override
+  public void onTimeout(AsyncEvent event) throws IOException {
+    ((HttpServletResponse) event.getSuppliedResponse()).sendError(500, "Timeout");
+    event.getAsyncContext().complete();
+  }
+
+  @Override
+  public void onError(AsyncEvent event) throws IOException {
+    // empty
+  }
+
+  @Override
+  public void onStartAsync(AsyncEvent event) throws IOException {
+    // empty
+  }
+
+  public static TimeoutListener getInstance() {
+    return INSTANCE;
+  }
+}

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerConfigTest.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerConfigTest.java
@@ -27,8 +27,6 @@ import static org.junit.Assert.assertEquals;
 
 public class HttpServerConfigTest {
 
-  private static final String SERVICE_NAME = "http-test-service-name";
-
   @Test
   public void canConfigureAddressAndPort() {
     String addr = "someaddr";
@@ -77,23 +75,7 @@ public class HttpServerConfigTest {
     assertEquals(keepAliveTimeout, http.keepAliveTimeout());
   }
 
-  @Test
-  public void hasNoRegistrationNameByDefault() {
-    String json = "{\"http\":{\"server\":{}}}";
-
-    HttpServerConfig http = conf(json);
-    assertEquals(SERVICE_NAME, http.registrationName());
-  }
-
-  @Test
-  public void canConfigureRegistrationName() {
-    String json = "{\"http\":{\"server\":{\"registrationName\": \"foobar\"}}}";
-
-    HttpServerConfig http = conf(json);
-    assertEquals("foobar", http.registrationName());
-  }
-
   private static HttpServerConfig conf(String json) {
-    return new HttpServerConfig(SERVICE_NAME, ConfigFactory.parseString(json));
+    return new HttpServerConfig(ConfigFactory.parseString(json));
   }
 }

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerConfigTest.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerConfigTest.java
@@ -48,33 +48,6 @@ public class HttpServerConfigTest {
     assertEquals(ttlMillis, http.ttlMillis());
   }
 
-  @Test
-  public void canConfigureWorkerThreads() {
-    long workerThreads = 123L;
-    String json = "{\"http\":{\"server\":{\"workerThreads\": 123}}}";
-
-    HttpServerConfig http = conf(json);
-    assertEquals(workerThreads, http.workerThreads());
-  }
-
-  @Test
-  public void canConfigureMaxHttpChunkLength() {
-    long maxHttpChunkLength = 123L;
-    String json = "{\"http\":{\"server\":{\"maxHttpChunkLength\": 123}}}";
-
-    HttpServerConfig http = conf(json);
-    assertEquals(maxHttpChunkLength, http.maxHttpChunkLength());
-  }
-
-  @Test
-  public void canConfigureKeepAliveTimeout() {
-    long keepAliveTimeout = 123L;
-    String json = "{\"http\":{\"server\":{\"keepAliveTimeout\": 123}}}";
-
-    HttpServerConfig http = conf(json);
-    assertEquals(keepAliveTimeout, http.keepAliveTimeout());
-  }
-
   private static HttpServerConfig conf(String json) {
     return new HttpServerConfig(ConfigFactory.parseString(json));
   }

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/TimeoutListenerTest.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/TimeoutListenerTest.java
@@ -1,0 +1,68 @@
+/*
+ * -\-\-
+ * Spotify Apollo Jetty HTTP Server Module
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.http.server;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.AsyncEvent;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TimeoutListenerTest {
+
+  private TimeoutListener listener;
+
+  private MockHttpServletResponse response;
+  @Mock
+  private AsyncContext asyncContext;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    response = new MockHttpServletResponse();
+    listener = TimeoutListener.getInstance();
+
+    when(asyncContext.getResponse()).thenReturn(response);
+  }
+
+  @Test
+  public void shouldSendErrorResponseOnTimeout() throws Exception {
+    listener.onTimeout(new AsyncEvent(asyncContext));
+
+    assertThat(response.getStatus(), is(500));
+    assertThat(response.getErrorMessage(), is("Timeout"));
+  }
+
+  @Test
+  public void shouldCompleteContextOnTimeout() throws Exception {
+    listener.onTimeout(new AsyncEvent(asyncContext));
+
+    verify(asyncContext).complete();
+  }
+}


### PR DESCRIPTION
The following is included:

- handling of timeouts from Jetty 
- configuration of Jetty timeouts based on Apollo config settings
- handling of dropped messages
- cleanup of config settings and documentation