### PR TITLE
ensure failures to respond are logged

### DIFF
--- a/apollo-api-impl/pom.xml
+++ b/apollo-api-impl/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>hamcrest-library</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>uk.org.lidalia</groupId>
+            <artifactId>slf4j-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/dispatch/EndpointInvocationHandlerTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/dispatch/EndpointInvocationHandlerTest.java
@@ -25,14 +25,23 @@ import com.spotify.apollo.Response;
 import com.spotify.apollo.request.OngoingRequest;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.helpers.MessageFormatter;
 
+import uk.org.lidalia.slf4jext.Level;
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
+import uk.org.lidalia.slf4jtest.TestLoggerFactoryResetRule;
+
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import okio.ByteString;
 
@@ -40,16 +49,19 @@ import static com.spotify.apollo.Status.INTERNAL_SERVER_ERROR;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EndpointInvocationHandlerTest {
-  EndpointInvocationHandler handler;
+  private EndpointInvocationHandler handler;
 
   @Mock private OngoingRequest ongoingRequest;
 
@@ -60,6 +72,11 @@ public class EndpointInvocationHandlerTest {
   @Captor private ArgumentCaptor<Response<ByteString>> messageArgumentCaptor;
 
   private CompletableFuture<Response<ByteString>> future;
+
+  private TestLogger testLogger = TestLoggerFactory.getTestLogger(EndpointInvocationHandler.class);
+
+  @Rule
+  public TestLoggerFactoryResetRule resetRule = new TestLoggerFactoryResetRule();
 
   @Before
   public void setUp() throws Exception {
@@ -165,5 +182,23 @@ public class EndpointInvocationHandlerTest {
 
     assertThat(messageArgumentCaptor.getValue().status().reasonPhrase(),
         containsString(exception.getMessage()));
+  }
+
+  @Test
+  public void shouldLogExceptionsWhenReplying() throws Exception {
+    when(endpoint.invoke(any(RequestContext.class)))
+        .thenReturn(completedFuture(response));
+    //noinspection unchecked
+    doThrow(new RuntimeException("log this exception!")).when(ongoingRequest).reply(any(Response.class));
+
+    handler.handle(ongoingRequest, requestContext, endpoint);
+
+    List<String> eventMessages = testLogger.getLoggingEvents().stream()
+        .filter(loggingEvent -> loggingEvent.getLevel() == Level.ERROR)
+        .map(loggingEvent -> MessageFormatter.arrayFormat(loggingEvent.getMessage(), loggingEvent.getArguments().toArray()).getMessage())
+        .collect(Collectors.toList());
+
+    assertThat(eventMessages, hasSize(1));
+    assertThat(eventMessages, hasItem(containsString("Exception caught when replying")));
   }
 }

--- a/apollo-api-impl/src/test/resources/slf4jtest.properties
+++ b/apollo-api-impl/src/test/resources/slf4jtest.properties
@@ -1,0 +1,1 @@
+print.level=INFO


### PR DESCRIPTION
Prior to this change, a failure to send a response (for an error or a correctly
handled request) to clients would remain 'sitting' in a failed CompletionStage.

Partial remediation for #156