### PR TITLE
ensure ServiceHelper includes the MetricsModule

### DIFF
--- a/apollo-test/pom.xml
+++ b/apollo-test/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>apollo-okhttp-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.spotify</groupId>
+            <artifactId>apollo-metrics</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value</artifactId>
             <scope>provided</scope>

--- a/apollo-test/src/main/java/com/spotify/apollo/test/ServiceHelper.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/ServiceHelper.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.Provides;
 
 import com.spotify.apollo.AppInit;
 import com.spotify.apollo.Client;
@@ -36,8 +37,11 @@ import com.spotify.apollo.core.Services;
 import com.spotify.apollo.environment.ApolloConfig;
 import com.spotify.apollo.environment.ApolloEnvironmentModule;
 import com.spotify.apollo.http.client.HttpClientModule;
+import com.spotify.apollo.metrics.MetricsModule;
+import com.spotify.apollo.module.AbstractApolloModule;
 import com.spotify.apollo.module.ApolloModule;
 import com.spotify.apollo.request.RequestHandler;
+import com.spotify.metrics.core.MetricId;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
@@ -63,6 +67,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+
+import javax.inject.Singleton;
 
 import okio.ByteString;
 
@@ -476,6 +482,8 @@ public class ServiceHelper implements TestRule, Closeable {
             .usingModuleDiscovery(false)
             .withModule(ApolloEnvironmentModule.create())
             .withModule(HttpClientModule.create())
+            .withModule(MetricsModule.create())
+            .withModule(new MetricIdModule())
             .withModule(
                 ForwardingStubClientModule
                     .create(forwardNonStubbedRequests, stubClient.asRequestAwareClient()));
@@ -538,6 +546,25 @@ public class ServiceHelper implements TestRule, Closeable {
       instance = null;
       Futures.getUnchecked(currentHelperFuture);
       currentHelperFuture = null;
+    }
+  }
+
+  private static class MetricIdModule extends AbstractApolloModule {
+    @Override
+    protected void configure() {
+
+    }
+
+    @Override
+    public String getId() {
+      return "servicehelper-metric-id";
+    }
+
+    @Provides
+    @Singleton
+    public MetricId metricId() {
+      return MetricId.build("apollo").tagged(
+          "service-framework", "service-helper");
     }
   }
 }

--- a/apollo-test/src/test/java/com/spotify/apollo/test/helper/ServiceHelperTest.java
+++ b/apollo-test/src/test/java/com/spotify/apollo/test/helper/ServiceHelperTest.java
@@ -27,6 +27,7 @@ import com.spotify.apollo.Response;
 import com.spotify.apollo.module.AbstractApolloModule;
 import com.spotify.apollo.test.ServiceHelper;
 import com.spotify.apollo.test.StubClient;
+import com.spotify.metrics.core.SemanticMetricRegistry;
 
 import org.junit.AfterClass;
 import org.junit.Rule;
@@ -70,7 +71,7 @@ public class ServiceHelperTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
-  StubClient stubClient = serviceHelper.stubClient();
+  private StubClient stubClient = serviceHelper.stubClient();
 
   @Mock
   SomeApplication.SomeService someService;
@@ -78,7 +79,7 @@ public class ServiceHelperTest {
   @Mock
   static SomeApplication.CloseCall closeCall;
 
-  void appInit(Environment environment) {
+  private void appInit(Environment environment) {
     SomeApplication someApplication =
         SomeApplication.create(environment, someService, closeCall);
 
@@ -252,7 +253,7 @@ public class ServiceHelperTest {
     withModule.start();
   }
 
-    @Test
+  @Test
   public void shouldUseScheme() throws Exception {
     ServiceHelper scheme = ServiceHelper.create(this::appInit, "test-service")
         .scheme("gopher+my-go.pher");
@@ -273,6 +274,17 @@ public class ServiceHelperTest {
     thrown.expectMessage("Illegal scheme format");
 
     ServiceHelper.create(this::appInit, "test-service").scheme("http://"); // invalid
+  }
+
+  @Test
+  public void shouldAllowSemanticMetricRegistryResolution() throws Exception {
+    ServiceHelper serviceHelper = ServiceHelper.create(this::resolveRegistry, "resolve-registry");
+
+    serviceHelper.start();
+  }
+
+  private void resolveRegistry(Environment environment) {
+    assertThat(environment.resolve(SemanticMetricRegistry.class), is(notNullValue()));
   }
 
   private static void tooSlow(Environment environment) {


### PR DESCRIPTION
Without this, tests of applications that do things like `Environment.resolve(SemanticMetricRegistry.class)` will break due to a missing Guice binding. 