### PR TITLE
Add request metadata to RequestContext

### DIFF
--- a/apollo-api-impl/src/main/java/com/spotify/apollo/request/OngoingRequest.java
+++ b/apollo-api-impl/src/main/java/com/spotify/apollo/request/OngoingRequest.java
@@ -20,6 +20,7 @@
 package com.spotify.apollo.request;
 
 import com.spotify.apollo.Request;
+import com.spotify.apollo.RequestMetadata;
 import com.spotify.apollo.Response;
 
 import java.net.InetSocketAddress;
@@ -29,7 +30,7 @@ import okio.ByteString;
 /**
  * A request that is being processed.
  */
-public interface OngoingRequest {
+public interface OngoingRequest extends RequestMetadata {
 
   InetSocketAddress PORT_ZERO = new InetSocketAddress(0);
   ServerInfo UNKNOWN_SERVER_INFO = ServerInfos.create("unknown", PORT_ZERO);
@@ -59,25 +60,4 @@ public interface OngoingRequest {
   void drop();
 
   boolean isExpired();
-
-  /**
-   * Get the arrival time of the incoming request in nanoseconds. Note that this is not
-   * unix epoch as the time is provided by {@link System#nanoTime()}. To get unix epoch
-   * time, do something like:
-   *
-   * <pre>
-   * {@code
-   * long processingTimeNanos = System.nanoTime() - requestContext.arrivalTimeNanos();
-   * long arrivalTimeUnixEpochMillis = System.currentTimeMillis() +
-   *                                   TimeUnit.NANOSECONDS.toMillis(processingTimeNanos);
-   * }
-   * </pre>
-   *
-   * @see System#nanoTime()
-   */
-  default long arrivalTimeNanos() {
-    // This is not a good default for real implementations. It is simply a catch-all
-    // default to not break existing implementations.
-    return System.nanoTime();
-  }
 }

--- a/apollo-api-impl/src/main/java/com/spotify/apollo/request/RequestContexts.java
+++ b/apollo-api-impl/src/main/java/com/spotify/apollo/request/RequestContexts.java
@@ -20,6 +20,7 @@
 package com.spotify.apollo.request;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
 
 import com.spotify.apollo.Client;
 import com.spotify.apollo.Request;
@@ -37,9 +38,20 @@ public abstract class RequestContexts implements RequestContext {
 
   public static RequestContext create(
       Request request, Client client, Map<String, String> pathArgs, long arrivalTimeNanos) {
-    return new AutoValue_RequestContexts(request, client, pathArgs, arrivalTimeNanos);
+    return create(request, client, pathArgs, arrivalTimeNanos, ImmutableMap.of());
   }
 
+  public static RequestContext create(
+      Request request, Client client, Map<String, String> pathArgs,
+      long arrivalTimeNanos, Map<String, String> metadata) {
+    return new AutoValue_RequestContexts(request, client, pathArgs, arrivalTimeNanos, metadata);
+  }
+
+  // override default implementation to ensure auto-value will generate a field for this
   @Override
   public abstract long arrivalTimeNanos();
+
+  // override default implementation to ensure auto-value will generate a field for this
+  @Override
+  public abstract Map<String, String> metadata();
 }

--- a/apollo-api-impl/src/main/java/com/spotify/apollo/request/RequestHandlerImpl.java
+++ b/apollo-api-impl/src/main/java/com/spotify/apollo/request/RequestHandlerImpl.java
@@ -85,7 +85,11 @@ class RequestHandlerImpl implements RequestHandler {
     final Map<String, String> parsedPathArguments = match.parsedPathArguments();
     final Client requestScopedClient = client.wrapRequest(request.request());
     final RequestContext requestContext =
-        RequestContexts.create(request.request(), requestScopedClient, parsedPathArguments, request.arrivalTimeNanos());
+        RequestContexts.create(request.request(),
+                               requestScopedClient,
+                               parsedPathArguments,
+                               request.arrivalTimeNanos(),
+                               request.metadata());
 
     erf.create(request, requestContext, endpoint)
         .run();

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/request/RequestHandlerImplTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/request/RequestHandlerImplTest.java
@@ -19,6 +19,8 @@
  */
 package com.spotify.apollo.request;
 
+import com.google.common.collect.ImmutableMap;
+
 import com.spotify.apollo.Request;
 import com.spotify.apollo.RequestContext;
 import com.spotify.apollo.Response;
@@ -130,6 +132,22 @@ public class RequestHandlerImplTest {
 
     final RequestContext requestContext = requestContextCaptor.getValue();
     assertThat(requestContext.arrivalTimeNanos(), is(ARRIVAL_TIME_NANOS));
+  }
+
+  @Test
+  public void shouldCopyRequestMetadataToContext() throws Exception {
+    ImmutableMap<String, String> expected = ImmutableMap.of("hi", "ho");
+    when(ongoingRequest.metadata()).thenReturn(expected);
+
+    requestHandler.handle(ongoingRequest);
+
+    verify(requestRunnable).run(continuationCaptor.capture());
+
+    continuationCaptor.getValue()
+        .accept(ongoingRequest, match);
+
+    final RequestContext requestContext = requestContextCaptor.getValue();
+    assertThat(requestContext.metadata(), is(expected));
   }
 
   private static class NoopClient implements IncomingRequestAwareClient {

--- a/apollo-api/src/main/java/com/spotify/apollo/RequestContext.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/RequestContext.java
@@ -24,7 +24,7 @@ import java.util.Map;
 /**
  * This object contains all the needed information related to an incoming request.
  */
-public interface RequestContext {
+public interface RequestContext extends RequestMetadata {
 
   /**
    * Get the incoming request message.
@@ -50,25 +50,4 @@ public interface RequestContext {
    * { "param" : "over", "param2": "the%32rainbow" }.
    */
   Map<String, String> pathArgs();
-
-  /**
-   * Get the arrival time of the incoming request in nanoseconds. Note that this is not
-   * unix epoch as the time is provided by {@link System#nanoTime()}. To get unix epoch
-   * time, do something like:
-   *
-   * <pre>
-   * {@code
-   * long processingTimeNanos = System.nanoTime() - requestContext.arrivalTimeNanos();
-   * long arrivalTimeUnixEpochMillis = System.currentTimeMillis() +
-   *                                   TimeUnit.NANOSECONDS.toMillis(processingTimeNanos);
-   * }
-   * </pre>
-   *
-   * @see System#nanoTime()
-   */
-  default long arrivalTimeNanos() {
-    // This is not a good default for real implementations. It is simply a catch-all
-    // default to not break existing implementations.
-    return System.nanoTime();
-  }
 }

--- a/apollo-api/src/main/java/com/spotify/apollo/RequestMetadata.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/RequestMetadata.java
@@ -1,0 +1,65 @@
+/*
+ * -\-\-
+ * Spotify Apollo API Interfaces
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/**
+ * Describes an API for retrieving metadata about an incoming request.
+ */
+public interface RequestMetadata {
+
+  String METADATA_SOURCE = "apollo.metadata-source";
+
+  /**
+   * Get the arrival time of the incoming request in nanoseconds. Note that this is not
+   * unix epoch as the time is provided by {@link System#nanoTime()}. To get unix epoch
+   * time, do something like:
+   *
+   * <pre>
+   * {@code
+   * long processingTimeNanos = System.nanoTime() - requestContext.arrivalTimeNanos();
+   * long arrivalTimeUnixEpochMillis = System.currentTimeMillis() +
+   *                                   TimeUnit.NANOSECONDS.toMillis(processingTimeNanos);
+   * }
+   * </pre>
+   *
+   * @see System#nanoTime()
+   */
+  default long arrivalTimeNanos() {
+    // This is not a good default for real implementations. It is simply a catch-all
+    // default to not break existing implementations.
+    return System.nanoTime();
+  }
+
+  /**
+   * Returns metadata for this request; may include things like information about the origin of the
+   * request (remote IP address of the connected socket), etc. The exact content is server
+   * implementation-dependent. Implementations are encouraged to clearly document which set of keys
+   * and values they will record as request metadata. All implementations are encouraged to set
+   * a value for the key {@link #METADATA_SOURCE}, indicating a Java class that generated the
+   * metadata; this enables users to more easily understand what data to expect.
+   */
+  default Map<String, String> metadata() {
+    return ImmutableMap.of();
+  }
+}

--- a/apollo-http-service/src/test/resources/metadatatest.conf
+++ b/apollo-http-service/src/test/resources/metadatatest.conf
@@ -1,0 +1,1 @@
+http.server.port=29432

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/AsyncContextOngoingRequest.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/AsyncContextOngoingRequest.java
@@ -19,6 +19,8 @@
  */
 package com.spotify.apollo.http.server;
 
+import com.google.common.collect.ImmutableMap;
+
 import com.spotify.apollo.Request;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.Status;
@@ -30,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -53,14 +56,17 @@ class AsyncContextOngoingRequest implements OngoingRequest {
   private final AsyncContext asyncContext;
   private final RequestOutcomeConsumer logger;
   private final AtomicBoolean replied = new AtomicBoolean(false);
+  private final Map<String, String> metadata;
 
   AsyncContextOngoingRequest(ServerInfo serverInfo, Request request, AsyncContext asyncContext,
-                             long arrivalTimeNanos, RequestOutcomeConsumer logger) {
+                             long arrivalTimeNanos, RequestOutcomeConsumer logger,
+                             Map<String, String> metadata) {
     this.serverInfo = serverInfo;
     this.request = requireNonNull(request);
     this.asyncContext = requireNonNull(asyncContext);
     this.arrivalTimeNanos = arrivalTimeNanos;
     this.logger = requireNonNull(logger);
+    this.metadata = ImmutableMap.copyOf(metadata);
   }
 
   @Override
@@ -118,5 +124,10 @@ class AsyncContextOngoingRequest implements OngoingRequest {
   @Override
   public long arrivalTimeNanos() {
     return arrivalTimeNanos;
+  }
+
+  @Override
+  public Map<String, String> metadata() {
+    return metadata;
   }
 }

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/JettyHttpRequestMetadata.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/JettyHttpRequestMetadata.java
@@ -1,0 +1,30 @@
+/*
+ * -\-\-
+ * Spotify Apollo Jetty HTTP Server Module
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.http.server;
+
+/**
+ * Defines the metadata reported for {@link com.spotify.apollo.RequestContext}s originating from
+ * this server.
+ */
+public enum JettyHttpRequestMetadata {
+  PROTOCOL_VERSION,
+  REMOTE_ADDRESS,
+  REMOTE_PORT
+}

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/AsyncContextOngoingRequestTest.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/AsyncContextOngoingRequestTest.java
@@ -19,6 +19,8 @@
  */
 package com.spotify.apollo.http.server;
 
+import com.google.common.collect.ImmutableMap;
+
 import com.spotify.apollo.Request;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.Status;
@@ -110,7 +112,8 @@ public class AsyncContextOngoingRequestTest {
         REQUEST,
         asyncContext,
         ARRIVAL_TIME_NANOS,
-        logger);
+        logger,
+        ImmutableMap.of());
   }
 
   // note: this test may fail when running in IntelliJ, due to
@@ -196,7 +199,7 @@ public class AsyncContextOngoingRequestTest {
     Subclassed(ServerInfo serverInfo, Request request,
                AsyncContext asyncContext, long arrivalTimeNanos,
                RequestOutcomeConsumer logger) {
-      super(serverInfo, request, asyncContext, arrivalTimeNanos, logger);
+      super(serverInfo, request, asyncContext, arrivalTimeNanos, logger, ImmutableMap.of());
     }
 
     @Override

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsCollectingEndpointRunnableFactoryDecorator.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsCollectingEndpointRunnableFactoryDecorator.java
@@ -58,7 +58,9 @@ class MetricsCollectingEndpointRunnableFactoryDecorator implements EndpointRunna
           RequestContexts.create(
               requestContext.request(),
               instrumentingClient,
-              requestContext.pathArgs());
+              requestContext.pathArgs(),
+              requestContext.arrivalTimeNanos(),
+              requestContext.metadata());
 
       return delegate.create(trackedRequest, instrumentingContext, endpoint);
     };


### PR DESCRIPTION
Adds a facility allowing server implementations to annotate
incoming requests with metadata that can then be used in
request handlers. Also adds an implementation in HttpService
that provides the metadata that has been requested to date.

Fixes #129
Fixes #148