### PR TITLE
Add request metadata to RequestContext

### DIFF
--- a/apollo-api-impl/src/main/java/com/spotify/apollo/request/ForwardingOngoingRequest.java
+++ b/apollo-api-impl/src/main/java/com/spotify/apollo/request/ForwardingOngoingRequest.java
@@ -20,6 +20,7 @@
 package com.spotify.apollo.request;
 
 import com.spotify.apollo.Request;
+import com.spotify.apollo.RequestMetadata;
 import com.spotify.apollo.Response;
 
 import java.util.Objects;
@@ -65,5 +66,10 @@ public abstract class ForwardingOngoingRequest implements OngoingRequest {
   @Override
   public long arrivalTimeNanos() {
     return delegate.arrivalTimeNanos();
+  }
+
+  @Override
+  public RequestMetadata metadata() {
+    return delegate.metadata();
   }
 }

--- a/apollo-api-impl/src/main/java/com/spotify/apollo/request/OngoingRequest.java
+++ b/apollo-api-impl/src/main/java/com/spotify/apollo/request/OngoingRequest.java
@@ -20,9 +20,12 @@
 package com.spotify.apollo.request;
 
 import com.spotify.apollo.Request;
+import com.spotify.apollo.RequestMetadata;
 import com.spotify.apollo.Response;
 
 import java.net.InetSocketAddress;
+import java.time.Instant;
+import java.util.Optional;
 
 import okio.ByteString;
 
@@ -41,7 +44,10 @@ public interface OngoingRequest {
 
   /**
    * Returns an identifier for the server where this request originated.
+   *
+   * @deprecated  - prefer using the {@link #metadata()} method to get this information
    */
+  @Deprecated
   default ServerInfo serverInfo() {
     return UNKNOWN_SERVER_INFO;
   }
@@ -74,10 +80,19 @@ public interface OngoingRequest {
    * </pre>
    *
    * @see System#nanoTime()
+   * @deprecated - prefer using the {@link #metadata()} to get this information
    */
+  @Deprecated
   default long arrivalTimeNanos() {
     // This is not a good default for real implementations. It is simply a catch-all
     // default to not break existing implementations.
     return System.nanoTime();
+  }
+
+  /**
+   * Returns the metadata available for this request.
+   */
+  default RequestMetadata metadata() {
+    return RequestMetadataImpl.create(Instant.now(), Optional.empty(), Optional.empty());
   }
 }

--- a/apollo-api-impl/src/main/java/com/spotify/apollo/request/RequestContexts.java
+++ b/apollo-api-impl/src/main/java/com/spotify/apollo/request/RequestContexts.java
@@ -24,22 +24,54 @@ import com.google.auto.value.AutoValue;
 import com.spotify.apollo.Client;
 import com.spotify.apollo.Request;
 import com.spotify.apollo.RequestContext;
+import com.spotify.apollo.RequestMetadata;
 
+import java.time.Instant;
 import java.util.Map;
+import java.util.Optional;
 
 @AutoValue
 public abstract class RequestContexts implements RequestContext {
 
+  /**
+   * @deprecated - prefer {@link #create(Request, Client, Map, long, RequestMetadata)} to specify
+   * correct metadata.
+   */
+  @Deprecated
   public static RequestContext create(
       Request request, Client client, Map<String, String> pathArgs) {
     return create(request, client, pathArgs, System.nanoTime());
   }
 
-  public static RequestContext create(
-      Request request, Client client, Map<String, String> pathArgs, long arrivalTimeNanos) {
-    return new AutoValue_RequestContexts(request, client, pathArgs, arrivalTimeNanos);
+  /**
+   * @deprecated - prefer {@link #create(Request, Client, Map, long, RequestMetadata)} to specify
+   * correct metadata.
+   */
+  @Deprecated
+  public static RequestContext create(Request request, Client client, Map<String, String> pathArgs, long arrivalTimeNanos) {
+    return create(
+        request,
+        client,
+        pathArgs,
+        arrivalTimeNanos,
+        RequestMetadataImpl.create(Instant.EPOCH, Optional.empty(), Optional.empty())
+    );
   }
+
+  public static RequestContext create(
+      Request request,
+      Client client,
+      Map<String, String> pathArgs,
+      long arrivalTimeNanos,
+      RequestMetadata metadata) {
+    return new AutoValue_RequestContexts(request, client, pathArgs, arrivalTimeNanos, metadata);
+  }
+
+  // override default methods from interface to ensure AutoValue generates fields
 
   @Override
   public abstract long arrivalTimeNanos();
+
+  @Override
+  public abstract RequestMetadata metadata();
 }

--- a/apollo-api-impl/src/main/java/com/spotify/apollo/request/RequestHandlerImpl.java
+++ b/apollo-api-impl/src/main/java/com/spotify/apollo/request/RequestHandlerImpl.java
@@ -85,7 +85,11 @@ class RequestHandlerImpl implements RequestHandler {
     final Map<String, String> parsedPathArguments = match.parsedPathArguments();
     final Client requestScopedClient = client.wrapRequest(request.request());
     final RequestContext requestContext =
-        RequestContexts.create(request.request(), requestScopedClient, parsedPathArguments, request.arrivalTimeNanos());
+        RequestContexts.create(request.request(),
+                               requestScopedClient,
+                               parsedPathArguments,
+                               request.arrivalTimeNanos(),
+                               request.metadata());
 
     erf.create(request, requestContext, endpoint)
         .run();

--- a/apollo-api-impl/src/main/java/com/spotify/apollo/request/RequestMetadataImpl.java
+++ b/apollo-api-impl/src/main/java/com/spotify/apollo/request/RequestMetadataImpl.java
@@ -1,0 +1,50 @@
+/*
+ * -\-\-
+ * Spotify Apollo API Implementations
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.request;
+
+import com.google.auto.value.AutoValue;
+
+import com.spotify.apollo.RequestMetadata;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Immutable value object for request metadata.
+ */
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+@AutoValue
+public abstract class RequestMetadataImpl implements RequestMetadata {
+
+  public static RequestMetadata create(Instant arrivalTime,
+                                       Optional<HostAndPort> localAddress,
+                                       Optional<HostAndPort> remoteAddress) {
+    return new AutoValue_RequestMetadataImpl(arrivalTime, localAddress, remoteAddress);
+  }
+
+  public static HostAndPort hostAndPort(String host, int port) {
+    return new AutoValue_RequestMetadataImpl_HostAndPortImpl(host, port);
+  }
+
+  @AutoValue
+  public static abstract class HostAndPortImpl implements RequestMetadata.HostAndPort {
+
+  }
+}

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/request/ForwardingOngoingRequestTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/request/ForwardingOngoingRequestTest.java
@@ -1,0 +1,93 @@
+/*
+ * -\-\-
+ * Spotify Apollo API Implementations
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.request;
+
+import com.spotify.apollo.Response;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.verify;
+
+public class ForwardingOngoingRequestTest {
+  private ForwardingOngoingRequest forwardingOngoingRequest;
+
+  @Mock
+  private OngoingRequest delegate;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    forwardingOngoingRequest = new ForwardingOngoingRequest(delegate) {
+    };
+  }
+
+  @Test
+  public void shouldForwardRequestMethod() throws Exception {
+    forwardingOngoingRequest.request();
+
+    verify(delegate).request();
+  }
+
+  @Test
+  public void shouldForwardDrop() throws Exception {
+    forwardingOngoingRequest.drop();
+
+    verify(delegate).drop();
+  }
+
+  @Test
+  public void shouldForwardReply() throws Exception {
+    forwardingOngoingRequest.reply(Response.ok());
+
+    verify(delegate).reply(Response.ok());
+  }
+
+  @Test
+  public void shouldForwardMetadata() throws Exception {
+    forwardingOngoingRequest.metadata();
+
+    verify(delegate).metadata();
+  }
+
+  @Test
+  public void shouldForwardArrivalTime() throws Exception {
+    forwardingOngoingRequest.arrivalTimeNanos();
+
+    verify(delegate).arrivalTimeNanos();
+  }
+
+  @Test
+  public void shouldForwardIsExpired() throws Exception {
+    forwardingOngoingRequest.isExpired();
+
+    verify(delegate).isExpired();
+  }
+
+  @Test
+  public void shouldForwardServerInfo() throws Exception {
+    forwardingOngoingRequest.serverInfo();
+
+    verify(delegate).serverInfo();
+  }
+}

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/request/RequestHandlerImplTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/request/RequestHandlerImplTest.java
@@ -21,6 +21,7 @@ package com.spotify.apollo.request;
 
 import com.spotify.apollo.Request;
 import com.spotify.apollo.RequestContext;
+import com.spotify.apollo.RequestMetadata;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.dispatch.Endpoint;
 import com.spotify.apollo.dispatch.EndpointInfo;
@@ -36,6 +37,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiConsumer;
@@ -55,8 +57,6 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class RequestHandlerImplTest {
 
-  private static final long ARRIVAL_TIME_NANOS = 4711L;
-
   @Mock RequestRunnableFactory requestFactory;
   @Mock EndpointRunnableFactory endpointFactory;
 
@@ -73,11 +73,15 @@ public class RequestHandlerImplTest {
 
   RequestHandlerImpl requestHandler;
 
+  private RequestMetadata requestMetadata;
+
   @Before
   public void setUp() throws Exception {
     IncomingRequestAwareClient client = new NoopClient();
 
-    when(ongoingRequest.arrivalTimeNanos()).thenReturn(ARRIVAL_TIME_NANOS);
+    requestMetadata = RequestMetadataImpl.create(Instant.ofEpochSecond(4711L), Optional.empty(), Optional.empty());
+
+    when(ongoingRequest.metadata()).thenReturn(requestMetadata);
     when(ongoingRequest.request()).thenReturn(Request.forUri("http://foo"));
     when(requestFactory.create(any())).thenReturn(requestRunnable);
     when(endpointFactory.create(eq(ongoingRequest), requestContextCaptor.capture(), eq(endpoint)))
@@ -120,7 +124,7 @@ public class RequestHandlerImplTest {
   }
 
   @Test
-  public void shouldSetRequestContextArrivalTime() throws Exception {
+  public void shouldSetRequestContextMetadata() throws Exception {
     requestHandler.handle(ongoingRequest);
 
     verify(requestRunnable).run(continuationCaptor.capture());
@@ -129,7 +133,7 @@ public class RequestHandlerImplTest {
         .accept(ongoingRequest, match);
 
     final RequestContext requestContext = requestContextCaptor.getValue();
-    assertThat(requestContext.arrivalTimeNanos(), is(ARRIVAL_TIME_NANOS));
+    assertThat(requestContext.metadata(), is(requestMetadata));
   }
 
   private static class NoopClient implements IncomingRequestAwareClient {

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/route/RouteEndpointTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/route/RouteEndpointTest.java
@@ -24,11 +24,13 @@ import com.spotify.apollo.Request;
 import com.spotify.apollo.RequestContext;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.request.RequestContexts;
+import com.spotify.apollo.request.RequestMetadataImpl;
 import com.spotify.apollo.route.Route.DocString;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 
@@ -64,7 +66,9 @@ public class RouteEndpointTest {
     asyncHandler = mock(AsyncHandler.class);
 
     Request request = Request.forUri("http://foo");
-    requestContext = RequestContexts.create(request, mock(Client.class), pathArgs);
+    requestContext = RequestContexts.create(request, mock(Client.class), pathArgs,
+                                            0L,
+                                            RequestMetadataImpl.create(Instant.EPOCH, Optional.empty(), Optional.empty()));
 
     theData = ByteString.encodeUtf8("theString");
     response = Response.forPayload(theData);

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/route/RouteRuleBuilderTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/route/RouteRuleBuilderTest.java
@@ -25,6 +25,7 @@ import com.spotify.apollo.RequestContext;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.dispatch.Endpoint;
 import com.spotify.apollo.request.RequestContexts;
+import com.spotify.apollo.request.RequestMetadataImpl;
 
 import org.junit.experimental.theories.DataPoint;
 import org.junit.experimental.theories.DataPoints;
@@ -32,6 +33,7 @@ import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -113,14 +115,18 @@ public class RouteRuleBuilderTest {
 
     return endpoint.invoke(
         RequestContexts.create(
-            requestContext.request(), requestContext.requestScopedClient(), parsedPathArguments)
+            requestContext.request(), requestContext.requestScopedClient(), parsedPathArguments,
+            0L,
+            RequestMetadataImpl.create(Instant.EPOCH, Optional.empty(), Optional.empty()))
     ).toCompletableFuture().get();
   }
 
   private Request request(String method, String uri) {
     client = mock(Client.class);
     message = Request.forUri(BASE_URI + uri, method);
-    requestContext = RequestContexts.create(message, client, Collections.emptyMap());
+    requestContext = RequestContexts.create(message, client, Collections.emptyMap(),
+                                            0L,
+                                            RequestMetadataImpl.create(Instant.EPOCH, Optional.empty(), Optional.empty()));
 
     return message;
   }

--- a/apollo-api/src/main/java/com/spotify/apollo/RequestContext.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/RequestContext.java
@@ -19,7 +19,9 @@
  */
 package com.spotify.apollo;
 
+import java.time.Instant;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * This object contains all the needed information related to an incoming request.
@@ -65,10 +67,35 @@ public interface RequestContext {
    * </pre>
    *
    * @see System#nanoTime()
+   * @deprecated - prefer using the {@link #metadata()} to get this information. This method will be
+   *               removed in the next major release.
    */
+  @Deprecated
   default long arrivalTimeNanos() {
     // This is not a good default for real implementations. It is simply a catch-all
     // default to not break existing implementations.
     return System.nanoTime();
+  }
+
+  /**
+   * Returns the metadata available for this request.
+   */
+  default RequestMetadata metadata() {
+    return new RequestMetadata() {
+      @Override
+      public Instant arrivalTime() {
+        return Instant.EPOCH;
+      }
+
+      @Override
+      public Optional<HostAndPort> localAddress() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Optional<HostAndPort> remoteAddress() {
+        return Optional.empty();
+      }
+    };
   }
 }

--- a/apollo-api/src/main/java/com/spotify/apollo/RequestMetadata.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/RequestMetadata.java
@@ -1,0 +1,60 @@
+/*
+ * -\-\-
+ * Spotify Apollo API Interfaces
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Describes an API for retrieving metadata about an incoming request. Implementations that wish to
+ * enable tracking of additional metadata are expected to extend this interface with more methods to
+ * return this additional data.
+ */
+public interface RequestMetadata {
+
+  /**
+   * Get the arrival time of the incoming request.
+   */
+  Instant arrivalTime();
+
+  /**
+   * Indicates the local address of the connection which the request was received on, if available
+   */
+  Optional<HostAndPort> localAddress();
+
+  /**
+   * Indicates the remote address of the connection which the request was received on, if available.
+   * This may be the address of a proxy address or a direct connection to the caller, depending on
+   * the network setup.
+   */
+  Optional<HostAndPort> remoteAddress();
+
+  /**
+   * Defines an address
+   */
+  interface HostAndPort {
+
+    /**
+     * May be a hostname or an IP address.
+     */
+    String host();
+    int port();
+  }
+}

--- a/apollo-api/src/test/java/com/spotify/apollo/route/TestRequestMetadata.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/route/TestRequestMetadata.java
@@ -1,0 +1,34 @@
+/*
+ * -\-\-
+ * Spotify Apollo API Interfaces
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.route;
+
+import com.google.auto.value.AutoValue;
+
+import com.spotify.apollo.RequestMetadata;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@AutoValue
+abstract class TestRequestMetadata implements RequestMetadata {
+  static RequestMetadata empty() {
+    return new AutoValue_TestRequestMetadata(Instant.EPOCH, Optional.empty(), Optional.empty());
+  }
+}

--- a/apollo-environment/pom.xml
+++ b/apollo-environment/pom.xml
@@ -85,6 +85,11 @@
             <artifactId>hamcrest-library</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apollo-environment/src/test/java/com/spotify/apollo/environment/ApolloEnvironmentModuleTest.java
+++ b/apollo-environment/src/test/java/com/spotify/apollo/environment/ApolloEnvironmentModuleTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.spotify.apollo.AppInit;
 import com.spotify.apollo.Environment;
 import com.spotify.apollo.Request;
+import com.spotify.apollo.RequestMetadata;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.Status;
 import com.spotify.apollo.core.Service;
@@ -31,6 +32,7 @@ import com.spotify.apollo.core.Services;
 import com.spotify.apollo.meta.MetaModule;
 import com.spotify.apollo.request.OngoingRequest;
 import com.spotify.apollo.request.RequestHandler;
+import com.spotify.apollo.request.RequestMetadataImpl;
 import com.spotify.apollo.route.Route;
 
 import org.hamcrest.Description;
@@ -40,7 +42,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -50,19 +54,16 @@ import okio.ByteString;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class ApolloEnvironmentModuleTest {
 
-  static final String[] ZERO_ARGS = new String[0];
+  private static final String[] ZERO_ARGS = new String[0];
 
-  ApolloEnvironmentModule appModule;
-  Service.Builder service;
+  private ApolloEnvironmentModule appModule;
+  private Service.Builder service;
 
   @Before
   public void setUp() throws Exception {
@@ -199,11 +200,11 @@ public class ApolloEnvironmentModuleTest {
           });
       assertNotNull(handler);
 
-      final OngoingRequest ongoingRequest = ongoingRequest("http://foo");
+      final FakeOngoingRequest ongoingRequest = ongoingRequest("http://foo");
 
       handler.handle(ongoingRequest);
+      assertThat(ongoingRequest.getReply(), hasStatus(Status.GONE));
       assertEquals("hello", lastResponseRef.get());
-      verify(ongoingRequest).reply(argThat(hasStatus(Status.GONE)));
     } catch (IOException e) {
       fail(e.getMessage());
     }
@@ -224,10 +225,8 @@ public class ApolloEnvironmentModuleTest {
     };
   }
 
-  private OngoingRequest ongoingRequest(String uri) {
-    OngoingRequest ongoingRequest = mock(OngoingRequest.class);
-    when(ongoingRequest.request()).thenReturn(Request.forUri(uri));
-    return ongoingRequest;
+  private FakeOngoingRequest ongoingRequest(String uri) {
+    return new FakeOngoingRequest(Request.forUri(uri));
   }
 
   private static class EnvApp implements AppInit {
@@ -245,4 +244,41 @@ public class ApolloEnvironmentModuleTest {
     }
   }
 
+  private static class FakeOngoingRequest implements OngoingRequest {
+
+    private final Request request;
+    private volatile Response<ByteString> reply = null;
+
+    FakeOngoingRequest(Request request) {
+      this.request = request;
+    }
+
+    @Override
+    public Request request() {
+      return request;
+    }
+
+    @Override
+    public void reply(Response<ByteString> response) {
+      reply = response;
+    }
+
+    @Override
+    public void drop() {
+    }
+
+    @Override
+    public boolean isExpired() {
+      return false;
+    }
+
+    @Override
+    public RequestMetadata metadata() {
+      return RequestMetadataImpl.create(Instant.EPOCH, Optional.empty(), Optional.empty());
+    }
+
+    public Response<ByteString> getReply() {
+      return reply;
+    }
+  }
 }

--- a/apollo-extra/src/test/java/com/spotify/apollo/logging/extra/OutcomeReportingOngoingRequestTest.java
+++ b/apollo-extra/src/test/java/com/spotify/apollo/logging/extra/OutcomeReportingOngoingRequestTest.java
@@ -20,6 +20,7 @@
 package com.spotify.apollo.logging.extra;
 
 import com.spotify.apollo.Request;
+import com.spotify.apollo.RequestMetadata;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.request.OngoingRequest;
 
@@ -99,6 +100,11 @@ public class OutcomeReportingOngoingRequestTest {
     @Override
     public boolean isExpired() {
       return false;
+    }
+
+    @Override
+    public RequestMetadata metadata() {
+      return null;
     }
   }
 }

--- a/apollo-extra/src/test/java/com/spotify/apollo/logging/extra/RequestLoggingDecoratorTest.java
+++ b/apollo-extra/src/test/java/com/spotify/apollo/logging/extra/RequestLoggingDecoratorTest.java
@@ -20,6 +20,7 @@
 package com.spotify.apollo.logging.extra;
 
 import com.spotify.apollo.Request;
+import com.spotify.apollo.RequestMetadata;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.dispatch.Endpoint;
 import com.spotify.apollo.request.OngoingRequest;
@@ -216,6 +217,11 @@ public class RequestLoggingDecoratorTest {
     @Override
     public boolean isExpired() {
       return false;
+    }
+
+    @Override
+    public RequestMetadata metadata() {
+      return null;
     }
   }
 }

--- a/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/HttpServiceTest.java
+++ b/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/HttpServiceTest.java
@@ -21,30 +21,48 @@ package com.spotify.apollo.httpservice;
 
 import com.spotify.apollo.AppInit;
 import com.spotify.apollo.Environment;
+import com.spotify.apollo.RequestMetadata;
+import com.spotify.apollo.Response;
 import com.spotify.apollo.core.Service;
+import com.spotify.apollo.http.server.HttpRequestMetadata;
+import com.spotify.apollo.route.AsyncHandler;
+import com.spotify.apollo.route.Route;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+import okio.ByteString;
+
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 public class HttpServiceTest {
 
   // we need a static counter in order to be able to use the Class overload of
   // HttpService.boot
-  static final AtomicInteger counter = new AtomicInteger();
+  private static final AtomicInteger counter = new AtomicInteger();
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
+
+  private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
   @Before
   public void setUp() throws Exception {
@@ -91,7 +109,48 @@ public class HttpServiceTest {
     HttpService.boot(service, "run", "foo");
   }
 
-  static class BrokenService implements AppInit {
+  @Test
+  public void shouldPopulateRequestMetadata() throws Exception {
+    AtomicReference<RequestMetadata> metadataReference = new AtomicReference<>();
+
+    final InstanceWaiter waiter = new InstanceWaiter();
+
+    Future<?> future = executorService.submit(() -> {
+      try {
+        HttpService.boot(environment ->
+                             environment.routingEngine()
+                                 .registerRoute(Route.async("GET", "/meta", trackMeta(metadataReference))),
+                         "metadatatest",
+                         waiter);
+      } catch (LoadingException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    final Service.Instance instance = waiter.waitForInstance();
+
+    Request httpRequest = new Request.Builder()
+        .url("http://localhost:29432/meta")
+        .build();
+
+    new OkHttpClient().newCall(httpRequest).execute();
+
+    assertThat(((HttpRequestMetadata) metadataReference.get()).httpVersion(), is("HTTP/1.1"));
+
+    instance.getSignaller().signalShutdown();
+    instance.waitForShutdown();
+    future.get();
+  }
+
+  private AsyncHandler<Response<ByteString>> trackMeta(AtomicReference<RequestMetadata> metadata) {
+    return requestContext -> {
+      System.out.println("meta: " + requestContext.metadata());
+      metadata.set(requestContext.metadata());
+      return CompletableFuture.completedFuture(Response.<ByteString>ok());
+    };
+  }
+
+  private static class BrokenService implements AppInit {
 
     @Override
     public void create(Environment environment) {
@@ -99,7 +158,7 @@ public class HttpServiceTest {
     }
   }
 
-  static class InstanceWaiter implements InstanceListener {
+  private static class InstanceWaiter implements InstanceListener {
 
     private final CountDownLatch latch = new CountDownLatch(1);
 

--- a/apollo-http-service/src/test/resources/metadatatest.conf
+++ b/apollo-http-service/src/test/resources/metadatatest.conf
@@ -1,0 +1,1 @@
+http.server.port=29432

--- a/apollo-test/src/main/java/com/spotify/apollo/test/FakeOngoingRequest.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/FakeOngoingRequest.java
@@ -20,9 +20,13 @@
 package com.spotify.apollo.test;
 
 import com.spotify.apollo.Request;
+import com.spotify.apollo.RequestMetadata;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.request.OngoingRequest;
+import com.spotify.apollo.request.RequestMetadataImpl;
 
+import java.time.Instant;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -63,6 +67,11 @@ public class FakeOngoingRequest implements OngoingRequest {
   @Override
   public boolean isExpired() {
     return false;
+  }
+
+  @Override
+  public RequestMetadata metadata() {
+    return RequestMetadataImpl.create(Instant.EPOCH, Optional.empty(), Optional.empty());
   }
 
   /**

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpRequestMetadata.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpRequestMetadata.java
@@ -1,0 +1,49 @@
+/*
+ * -\-\-
+ * Spotify Apollo Jetty HTTP Server Module
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.http.server;
+
+import com.google.auto.value.AutoValue;
+
+import com.spotify.apollo.RequestMetadata;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Subclass adding HTTP-specific metadata for incoming requests.
+ */
+@AutoValue
+public abstract class HttpRequestMetadata implements RequestMetadata {
+  /**
+   * The value of the HTTP-Version in the incoming HTTP Request-Line
+   * as per https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html. That is, usually one of
+   * HTTP/1.0 and HTTP/1.1.
+   */
+  public abstract String httpVersion();
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  static HttpRequestMetadata create(
+      Instant arrivalTime,
+      Optional<HostAndPort> localAddress,
+      Optional<HostAndPort> remoteAddress,
+      String httpVersion) {
+    return new AutoValue_HttpRequestMetadata(arrivalTime, localAddress, remoteAddress, httpVersion);
+  }
+}

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerImpl.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerImpl.java
@@ -21,9 +21,9 @@ package com.spotify.apollo.http.server;
 
 import com.google.common.io.Closer;
 
+import com.spotify.apollo.RequestMetadata;
 import com.spotify.apollo.request.RequestHandler;
-import com.spotify.apollo.request.ServerInfo;
-import com.spotify.apollo.request.ServerInfos;
+import com.spotify.apollo.request.RequestMetadataImpl;
 
 import org.eclipse.jetty.server.Server;
 import org.slf4j.Logger;
@@ -38,7 +38,6 @@ import java.time.Duration;
 class HttpServerImpl implements HttpServer {
 
   private static final Logger LOG = LoggerFactory.getLogger(HttpServer.class);
-  private static final String SERVER_ID = "http";
 
   private final Closer closer;
   private final HttpServerConfig config;
@@ -60,8 +59,8 @@ class HttpServerImpl implements HttpServer {
     LOG.info("Starting Jetty HTTP server on {}:{}", config.address(), config.port());
     final InetSocketAddress serverSocketAddress =
         new InetSocketAddress(config.address(), config.port());
-    final ServerInfo serverInfo =
-        ServerInfos.create(SERVER_ID, serverSocketAddress);
+    final RequestMetadata.HostAndPort serverInfo =
+        RequestMetadataImpl.hostAndPort(config.address(), config.port());
 
     server = new Server(serverSocketAddress);
     server.setHandler(new ApolloRequestHandler(serverInfo, requestHandler,

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/ApolloRequestHandlerTest.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/ApolloRequestHandlerTest.java
@@ -22,10 +22,10 @@ package com.spotify.apollo.http.server;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import com.spotify.apollo.RequestMetadata;
 import com.spotify.apollo.request.OngoingRequest;
 import com.spotify.apollo.request.RequestHandler;
-import com.spotify.apollo.request.ServerInfo;
-import com.spotify.apollo.request.ServerInfos;
+import com.spotify.apollo.request.RequestMetadataImpl;
 
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.HttpInput;
@@ -36,7 +36,6 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.LinkedList;
@@ -55,7 +54,9 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.iterableWithSize;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -89,7 +90,7 @@ public class ApolloRequestHandlerTest {
 
     delegate = new FakeRequestHandler();
     response = new MockHttpServletResponse();
-    ServerInfo serverInfo = ServerInfos.create("id", InetSocketAddress.createUnresolved("localhost", 80));
+    RequestMetadata.HostAndPort serverInfo = RequestMetadataImpl.hostAndPort("localhost", 80);
 
     requestTimeout = Duration.ofMillis(8275523);
     requestHandler = new ApolloRequestHandler(serverInfo, delegate, requestTimeout, logger);
@@ -207,6 +208,25 @@ public class ApolloRequestHandlerTest {
     verify(asyncContext).setTimeout(requestTimeout.toMillis());
   }
 
+  @Test
+  public void shouldAddProtocolToOngoingRequest() throws Exception {
+    requestHandler.handle("/floop", baseRequest, httpServletRequest, response);
+
+    assertThat(requestMetadata().httpVersion(), is("HTTP/1.1"));
+  }
+
+  @Test
+  public void shouldAddRemoteAddressToOngoingRequest() throws Exception {
+    requestHandler.handle("/floop", baseRequest, httpServletRequest, response);
+
+    assertThat(requestMetadata().remoteAddress(), is(Optional.of(RequestMetadataImpl.hostAndPort("123.45.67.89", 8734))));
+  }
+
+  private HttpRequestMetadata requestMetadata() {
+    assertThat(delegate.requests, is(iterableWithSize(1)));
+    return (HttpRequestMetadata) delegate.requests.get(0).metadata();
+  }
+
   private MockHttpServletRequest mockRequest(
       String method, String requestURI, Map<String, String> headers) {
     QueryStringDecoder decoder = new QueryStringDecoder(requestURI);
@@ -223,6 +243,10 @@ public class ApolloRequestHandlerTest {
     mockHttpServletRequest.setQueryString(requestURI.replace(decoder.path() + "?", ""));
 
     headers.forEach(mockHttpServletRequest::addHeader);
+    mockHttpServletRequest.setProtocol("HTTP/1.1");
+    mockHttpServletRequest.setRemoteHost("123.45.67.89");
+    mockHttpServletRequest.setRemoteAddr("123.45.67.89");
+    mockHttpServletRequest.setRemotePort(8734);
 
     return mockHttpServletRequest;
   }

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsCollectingEndpointRunnableFactoryDecorator.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsCollectingEndpointRunnableFactoryDecorator.java
@@ -58,7 +58,9 @@ class MetricsCollectingEndpointRunnableFactoryDecorator implements EndpointRunna
           RequestContexts.create(
               requestContext.request(),
               instrumentingClient,
-              requestContext.pathArgs());
+              requestContext.pathArgs(),
+              requestContext.arrivalTimeNanos(),
+              requestContext.metadata());
 
       return delegate.create(trackedRequest, instrumentingContext, endpoint);
     };


### PR DESCRIPTION
Adds a facility allowing server implementations to annotate
incoming requests with metadata that can then be used in
request handlers. Also adds an implementation in HttpService
that provides the metadata that has been requested to date.

Fixes #129
Fixes #148

Applies #169 to the master branch