### PR TITLE
upgrade typesafe-config to version 1.3.1

### DIFF
--- a/apollo-bom/pom.xml
+++ b/apollo-bom/pom.xml
@@ -150,7 +150,7 @@
             <dependency>
                 <groupId>com.typesafe</groupId>
                 <artifactId>config</artifactId>
-                <version>1.2.1</version>
+                <version>1.3.1</version>
             </dependency>
             <dependency>
                 <groupId>io.javaslang</groupId>


### PR DESCRIPTION
The main purpose of the upgrade is to get access to the `include required(...)` feature to have includes that fail if the resource is not found.

For example, the config library already supports being able to include a second config file from the main one, such as

```yaml
foo = bar
include file('/etc/something/else.conf')
```

however if the resource being included fails to load, no error message is thrown by the typesafe-config library. This can be confusing if you use the `include` flavor that looks like `include '/etc/something/else.conf`, as the library uses some heuristics to decide if that string represents a URL, a file, or a classpath entry, and what it chooses might not be what is expected. No error is thrown if the included resource cannot be loaded (whether you use `'path'` or `file('path')`, which seems quite confusing if the developer is relying on a second resource to be merged into the main config.

v1.3.1 adds support for a "required include" so that you can instead do


```yaml
foo = bar
include required(file('/etc/something/else.conf'))
```

[Changelog for the typesafe-config library](https://github.com/typesafehub/config/blob/master/NEWS.md#131-september-24-2016). The changelog for the 1.3.x family of releases warns about ABI-incompatible changes compared to 1.2.x, but from a quick glance of the changes I do not see anything related to features that Apollo uses. 

One small additional improvement from the typesafe-config library now being built on Java 1.8 is that for anyone using the `long getDuration(String path, TimeUnit unit)` in `Config` there is now an overload  for `java.time.Duration getDuration(String path)`.