### PR TITLE
upgrade typesafe-config to version 1.3.1 (backport to 1.x branch)

### DIFF
--- a/apollo-bom/pom.xml
+++ b/apollo-bom/pom.xml
@@ -145,7 +145,7 @@
             <dependency>
                 <groupId>com.typesafe</groupId>
                 <artifactId>config</artifactId>
-                <version>1.2.1</version>
+                <version>1.3.1</version>
             </dependency>
             <dependency>
                 <groupId>io.javaslang</groupId>


### PR DESCRIPTION
a backport of #176 to the 1.x branch, assuming #176 makes sense in the first place.