### PR TITLE
clarify unimplemented RequestContext metadata

### DIFF
--- a/apollo-api/src/main/java/com/spotify/apollo/RequestContext.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/RequestContext.java
@@ -81,21 +81,6 @@ public interface RequestContext {
    * Returns the metadata available for this request.
    */
   default RequestMetadata metadata() {
-    return new RequestMetadata() {
-      @Override
-      public Instant arrivalTime() {
-        return Instant.EPOCH;
-      }
-
-      @Override
-      public Optional<HostAndPort> localAddress() {
-        return Optional.empty();
-      }
-
-      @Override
-      public Optional<HostAndPort> remoteAddress() {
-        return Optional.empty();
-      }
-    };
+    throw new UnsupportedOperationException("If you implement a RequestContext, you must override this method");
   }
 }


### PR DESCRIPTION
Previously, if users upgrading do not notice that there is a new
RequestContext.metadata() method, their code will start failing
in strange ways (requests timing out was the concrete example)
because of the values supplied by the default implementation. It's
a better solution to throw an exception, forcing implementations
to actually override this method.