### PR TITLE
remove default implementations that do more harm than good

### DIFF
--- a/apollo-api/src/main/java/com/spotify/apollo/RequestContext.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/RequestContext.java
@@ -71,31 +71,10 @@ public interface RequestContext {
    *               removed in the next major release.
    */
   @Deprecated
-  default long arrivalTimeNanos() {
-    // This is not a good default for real implementations. It is simply a catch-all
-    // default to not break existing implementations.
-    return System.nanoTime();
-  }
+  long arrivalTimeNanos();
 
   /**
    * Returns the metadata available for this request.
    */
-  default RequestMetadata metadata() {
-    return new RequestMetadata() {
-      @Override
-      public Instant arrivalTime() {
-        return Instant.EPOCH;
-      }
-
-      @Override
-      public Optional<HostAndPort> localAddress() {
-        return Optional.empty();
-      }
-
-      @Override
-      public Optional<HostAndPort> remoteAddress() {
-        return Optional.empty();
-      }
-    };
-  }
+  RequestMetadata metadata();
 }

--- a/apollo-api/src/test/java/com/spotify/apollo/route/TestContext.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/route/TestContext.java
@@ -37,10 +37,11 @@ abstract class TestContext implements RequestContext {
   }
 
   static RequestContext empty() {
-    return new AutoValue_TestContext(Request.forUri("/"), Collections.emptyMap());
+    return new AutoValue_TestContext(Request.forUri("/"), Collections.emptyMap(), 0,
+        TestRequestMetadata.empty());
   }
 
   static RequestContext forPathArgs(Map<String, String> pathArgs) {
-    return new AutoValue_TestContext(Request.forUri("/"), pathArgs);
+    return new AutoValue_TestContext(Request.forUri("/"), pathArgs, 0, TestRequestMetadata.empty());
   }
 }


### PR DESCRIPTION
Since we're breaking API compatibility in 2.0, we don't need these default
implementations.