### PR TITLE
ensure FakeOngoingRequest uses a better arrival timestamp

### DIFF
--- a/apollo-test/src/main/java/com/spotify/apollo/test/FakeOngoingRequest.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/FakeOngoingRequest.java
@@ -24,12 +24,10 @@ import com.spotify.apollo.RequestMetadata;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.request.OngoingRequest;
 import com.spotify.apollo.request.RequestMetadataImpl;
-
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-
 import okio.ByteString;
 
 /**
@@ -38,6 +36,7 @@ import okio.ByteString;
 public class FakeOngoingRequest implements OngoingRequest {
 
   private final Request request;
+  private final RequestMetadata requestMetadata;
   private final CompletableFuture<Response<ByteString>> reply = new CompletableFuture<>();
 
   /**
@@ -47,6 +46,8 @@ public class FakeOngoingRequest implements OngoingRequest {
    */
   public FakeOngoingRequest(Request request) {
     this.request = request;
+    this.requestMetadata =
+        RequestMetadataImpl.create(Instant.now(), Optional.empty(), Optional.empty());
   }
 
   @Override
@@ -71,7 +72,7 @@ public class FakeOngoingRequest implements OngoingRequest {
 
   @Override
   public RequestMetadata metadata() {
-    return RequestMetadataImpl.create(Instant.EPOCH, Optional.empty(), Optional.empty());
+    return requestMetadata;
   }
 
   /**

--- a/apollo-test/src/test/java/com/spotify/apollo/test/FakeOngoingRequestTest.java
+++ b/apollo-test/src/test/java/com/spotify/apollo/test/FakeOngoingRequestTest.java
@@ -1,0 +1,55 @@
+/*
+ * -\-\-
+ * Spotify Apollo Testing Helpers
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.spotify.apollo.Request;
+import java.time.Instant;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Test;
+
+public class FakeOngoingRequestTest {
+
+  @Test
+  public void shouldReturnRecentArrivalTime() throws Exception {
+    FakeOngoingRequest request = new FakeOngoingRequest(Request.forUri("http://foo"));
+
+    assertThat(request.metadata().arrivalTime(), is(recent()));
+  }
+
+  private Matcher<Instant> recent() {
+    return new TypeSafeMatcher<Instant>() {
+      @Override
+      protected boolean matchesSafely(Instant item) {
+        return item.isAfter(Instant.now().minusSeconds(1));
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText(
+            "an instant at most a second older than the current timestamp (" + Instant.now() + ")");
+      }
+    };
+  }
+}


### PR DESCRIPTION
Without this, tests using the ServiceHelper and sending real requests get incorrect
values for arrivalTime, leading to broken request handling.