### PR TITLE
Info and examples of metadata handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,46 @@ Examples from [spotify-api-example](examples/spotify-api-example):
 `$ curl http://localhost:8080/_meta/0/endpoints`
 
 ```json
-{"result":{"docstring":null,"endpoints":[{"methodName":"/albums/new[GET]","uri":"/albums/new","method":["GET"],"docstring":"Get the latest albums on Spotify.\n\nUses the public Spotify API https://api.spotify.com to get 'new' albums.","queryParameters":[]},{"methodName":"/ping[GET]","uri":"/ping","method":["GET"],"docstring":"Responds with a 'pong!' if the service is up.\n\nUseful endpoint for doing health checks.","queryParameters":[]},{"methodName":"/albums/hipster[GET]","uri":"/albums/hipster","method":["GET"],"docstring":"Get the hipster albums on Spotify.\n\nUses the public Spotify API https://api.spotify.com to get albums with the keyword 'hipster'.","queryParameters":[]},{"methodName":"/artists/toptracks/<country>[GET]","uri":"/artists/toptracks/<country>","method":["GET"],"docstring":"Get top tracks for a specified country.\n\nUses the public Spotify API at https://api.spotify.com to get the current top tracks for a specific country.","queryParameters":[]}]}}
+{
+  "result": {
+    "docstring": null,
+    "endpoints":[
+      {
+        "docstring": "Get the latest albums on Spotify.\n\nUses the public Spotify API https://api.spotify.com to get 'new' albums.",
+        "method": [
+          "GET"
+        ],
+        "methodName": "/albums/new[GET]",
+        "queryParameters":[],
+        "uri": "/albums/new"
+      },
+      {
+        "docstring": "Responds with a 'pong!' if the service is up.\n\nUseful endpoint for doing health checks.",
+        "method": [
+          "GET"
+        ],
+        "methodName": "/ping[GET]",
+        "queryParameters": [],
+        "uri": "/ping"
+      },
+      ...
+    ]
+  }
+}
 ```
 
 `$ curl http://localhost:8080/_meta/0/info`
 
 ```json
-{"result":{"componentId":"spotify-api-example-service","buildVersion":"spotify-api-example-service 1.3.1","containerVersion":"apollo-http2.0.0-SNAPSHOT","systemVersion":"java 1.8.0_111","serviceUptime":778.249}}
+{
+  "result": {
+    "buildVersion": "spotify-api-example-service 1.3.1",
+    "componentId": "spotify-api-example-service",
+    "containerVersion": "apollo-http2.0.0-SNAPSHOT",
+    "serviceUptime": 778.249,
+    "systemVersion": "java 1.8.0_111"
+  }
+}
 ```
 
 ### Links

--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ public static void init(Environment environment) {
 }
 ```
 
-> Note that, for an Apollo-based service, you can see the routes defined for a service by querying
-[`/_meta/0/endpoints`](apollo-api-impl/src/main/java/com/spotify/apollo/meta/model).
-
 The apollo-api library provides several ways to help you define your request/reply handlers.
 You can specify how responses should be serialized (such as JSON). Read more about
 this library in the [Apollo API Readme](apollo-api).
@@ -70,6 +67,23 @@ public final class App {
             .registerAutoRoute(Route.sync("GET", "/", rc -> "hello world"));
     }
  }
+```
+
+### Apollo Metadata
+[Metadata](apollo-api-impl/src/main/java/com/spotify/apollo/meta/model) about an Apollo-based service, such as endpoints, is generated at runtime. At Spotify we use this to keep track of our running services. More info can be found [here](https://apidays.nz/slides/iglesias_service_metadata.pdf).
+
+Examples from [spotify-api-example](examples/spotify-api-example):
+
+`$ curl http://localhost:8080/_meta/0/endpoints`
+
+```json
+{"result":{"docstring":null,"endpoints":[{"methodName":"/albums/new[GET]","uri":"/albums/new","method":["GET"],"docstring":"Get the latest albums on Spotify.\n\nUses the public Spotify API https://api.spotify.com to get 'new' albums.","queryParameters":[]},{"methodName":"/ping[GET]","uri":"/ping","method":["GET"],"docstring":"Responds with a 'pong!' if the service is up.\n\nUseful endpoint for doing health checks.","queryParameters":[]},{"methodName":"/albums/hipster[GET]","uri":"/albums/hipster","method":["GET"],"docstring":"Get the hipster albums on Spotify.\n\nUses the public Spotify API https://api.spotify.com to get albums with the keyword 'hipster'.","queryParameters":[]},{"methodName":"/artists/toptracks/<country>[GET]","uri":"/artists/toptracks/<country>","method":["GET"],"docstring":"Get top tracks for a specified country.\n\nUses the public Spotify API at https://api.spotify.com to get the current top tracks for a specific country.","queryParameters":[]}]}}
+```
+
+`$ curl http://localhost:8080/_meta/0/info`
+
+```json
+{"result":{"componentId":"spotify-api-example-service","buildVersion":"spotify-api-example-service 1.3.1","containerVersion":"apollo-http2.0.0-SNAPSHOT","systemVersion":"java 1.8.0_111","serviceUptime":778.249}}
 ```
 
 ### Links

--- a/examples/spotify-api-example/src/main/java/com/spotify/apollo/example/AlbumResource.java
+++ b/examples/spotify-api-example/src/main/java/com/spotify/apollo/example/AlbumResource.java
@@ -43,8 +43,12 @@ public class AlbumResource {
     // we can map them to the same middleware
     // Note that this could also have been set up as a single route to "/albums/<tag>".
     return Stream.of(
-        Route.async("GET", "/albums/new", context -> getAlbums(context, "new")),
-        Route.async("GET", "/albums/hipster", context -> getAlbums(context, "hipster"))
+        Route.async("GET", "/albums/new", context -> getAlbums(context, "new")).withDocString(
+				"Get the latest albums on Spotify.", 
+				"Uses the public Spotify API https://api.spotify.com to get 'new' albums."),
+        Route.async("GET", "/albums/hipster", context -> getAlbums(context, "hipster")).withDocString(
+				"Get hipster albums on Spotify.", 
+				"Uses the public Spotify API https://api.spotify.com to get albums with the keyword 'hipster'.")
     )
         .map(route -> route.withMiddleware(
             JsonSerializerMiddlewares.jsonSerializeResponse(objectWriter)));

--- a/examples/spotify-api-example/src/main/java/com/spotify/apollo/example/ArtistResource.java
+++ b/examples/spotify-api-example/src/main/java/com/spotify/apollo/example/ArtistResource.java
@@ -44,7 +44,9 @@ public class ArtistResource {
   public Stream<Route<AsyncHandler<Response<ByteString>>>> routes() {
     // The artist resource has one parameterized route.
     return Stream.of(
-        Route.async("GET", "/artists/toptracks/<country>", this::getArtistTopTracks)
+        Route.async("GET", "/artists/toptracks/<country>", this::getArtistTopTracks).withDocString(
+				"Get top tracks for a specified country.", 
+				"Uses the public Spotify API at https://api.spotify.com to get the current top tracks for a specific country.")
           .withMiddleware(JsonSerializerMiddlewares.jsonSerializeResponse(objectWriter))
     );
   }

--- a/examples/spotify-api-example/src/main/java/com/spotify/apollo/example/SpotifyApiExample.java
+++ b/examples/spotify-api-example/src/main/java/com/spotify/apollo/example/SpotifyApiExample.java
@@ -30,10 +30,18 @@ final class SpotifyApiExample {
     environment.routingEngine()
         .registerRoutes(albumResource.routes())
         .registerRoutes(artistResource.routes())
-        .registerRoute(Route.sync("GET", "/ping", SpotifyApiExample::ping));
+        .registerRoute(Route.sync("GET", "/ping", SpotifyApiExample::ping).withDocString(
+        		"Responds with a 'pong!' if the service is up.",
+        		"Useful endpoint for doing health checks."));
   }
-
-  public static Response<ByteString> ping(RequestContext requestContext) {
+  
+/**
+ * Responds with a "pong!" if the service is up.
+ * 
+ * @param requestContext The default request context.
+ * @return "pong!" if the service is up.
+ */
+public static Response<ByteString> ping(RequestContext requestContext) {
     return Response.ok().withPayload(ByteString.encodeUtf8("pong!"));
   }
 }


### PR DESCRIPTION
Added information about how metadata is automatically generated by Apollo at runtime. Updated `spotify-api-example` with proper DocString support:

![screen shot 2016-12-07 at 10 53 10](https://cloud.githubusercontent.com/assets/190856/20962871/62fefc64-bc6b-11e6-8ac4-6d5425b8e6f3.png)
