### PR TITLE
Make comparing status more convenient.

### DIFF
--- a/apollo-api/src/main/java/com/spotify/apollo/StatusType.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/StatusType.java
@@ -45,7 +45,7 @@ public interface StatusType {
    * @return true if code of this equals code of statusType
    */
   default boolean equalCode(StatusType statusType) {
-    return statusType != null && code() == statusType.code();
+    return code() == statusType.code();
   }
 
   /**
@@ -55,7 +55,7 @@ public interface StatusType {
    * @return true if family of this equals family of statusType
    */
   default boolean equalFamily(StatusType statusType) {
-    return statusType != null && family() == statusType.family();
+    return family() == statusType.family();
   }
 
   /**

--- a/apollo-api/src/main/java/com/spotify/apollo/StatusType.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/StatusType.java
@@ -39,6 +39,26 @@ public interface StatusType {
   StatusType withReasonPhrase(String reasonPhrase);
 
   /**
+   * Convenience method for comparing the code of two StatusType instances.
+   *
+   * @param statusType the instance to compare this to
+   * @return true if code of this equals code of statusType
+   */
+  default boolean equalCode(StatusType statusType) {
+    return statusType != null && code() == statusType.code();
+  }
+
+  /**
+   * Convenience method for comparing the family of two StatusType instances.
+   *
+   * @param statusType the instance to compare this to
+   * @return true if family of this equals family of statusType
+   */
+  default boolean equalFamily(StatusType statusType) {
+    return statusType != null && family() == statusType.family();
+  }
+
+  /**
    * Defines classes of status codes as described in
    * http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html, using the name Family since 'class'
    * is overloaded in Java.

--- a/apollo-api/src/test/java/com/spotify/apollo/StatusTest.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/StatusTest.java
@@ -64,7 +64,6 @@ public class StatusTest {
     assertTrue(Status.OK.equalFamily(Status.OK.withReasonPhrase("okidoki")));
     assertTrue(Status.OK.equalFamily(Status.NO_CONTENT));
     assertFalse(Status.OK.equalFamily(Status.NOT_FOUND));
-    assertFalse(Status.OK.equalFamily(null));
   }
 
   @Test
@@ -73,6 +72,5 @@ public class StatusTest {
     assertTrue(Status.OK.equalCode(Status.OK.withReasonPhrase("okidoki")));
     assertFalse(Status.OK.equalCode(Status.NO_CONTENT));
     assertFalse(Status.OK.equalCode(Status.NOT_FOUND));
-    assertFalse(Status.OK.equalCode(null));
   }
 }

--- a/apollo-api/src/test/java/com/spotify/apollo/StatusTest.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/StatusTest.java
@@ -25,7 +25,9 @@ import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class StatusTest {
 
@@ -54,5 +56,23 @@ public class StatusTest {
   public void shouldReplaceControlCharsInReasonPhrase() throws Exception {
     StatusType statusType = Status.ACCEPTED.withReasonPhrase("with control\7");
     assertThat(statusType.reasonPhrase(), is("with control "));
+  }
+
+  @Test
+  public void shouldHaveEqualFamily() throws Exception {
+    assertTrue(Status.OK.equalFamily(Status.OK));
+    assertTrue(Status.OK.equalFamily(Status.OK.withReasonPhrase("okidoki")));
+    assertTrue(Status.OK.equalFamily(Status.NO_CONTENT));
+    assertFalse(Status.OK.equalFamily(Status.NOT_FOUND));
+    assertFalse(Status.OK.equalFamily(null));
+  }
+
+  @Test
+  public void shouldHaveEqualCode() throws Exception {
+    assertTrue(Status.OK.equalCode(Status.OK));
+    assertTrue(Status.OK.equalCode(Status.OK.withReasonPhrase("okidoki")));
+    assertFalse(Status.OK.equalCode(Status.NO_CONTENT));
+    assertFalse(Status.OK.equalCode(Status.NOT_FOUND));
+    assertFalse(Status.OK.equalCode(null));
   }
 }


### PR DESCRIPTION
More than once I have seen code like this fail:
```
if (Status.OK == response.status()) {
```
or
```
if (Status.OK.equals(response.status()) {
```
because the status of the response has a different reason phrase. The current solution would be to use
```
if (Status.OK.code() == response.status().code()) {
```
This small patch would simplify this check and also signal to developers that regular equals method might not be what you want to use.