### PR TITLE
make CombinedFormatLogger public

### DIFF
--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/CombinedFormatLogger.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/CombinedFormatLogger.java
@@ -43,7 +43,7 @@ import static java.util.Objects.requireNonNull;
  *  - remote ident is not supported (always '-')
  *  - remote user is not supported (always '-')
  */
-final class CombinedFormatLogger {
+public final class CombinedFormatLogger {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CombinedFormatLogger.class);
   private static final DateTimeFormatter DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
@@ -80,7 +80,7 @@ final class CombinedFormatLogger {
     // prevent instantiation
   }
 
-  static RequestOutcomeConsumer logger() {
+  public static RequestOutcomeConsumer logger() {
     return LOG_WITH_COMBINED_FORMAT;
   }
 }


### PR DESCRIPTION
Allow someone who wants to change the RequestOutcomeLogger used by
HttpServerProvider to customize the default logging behavior by chaining
multiple consumers together (since RequestOutcomeLogger is a BiConsumer,
and therefore has an `andThen(..)` method).

For example: combining the default logging behavior with an additional
RequestOutcomeLogger which would emit something about the request logs
to logstash/elasticsearch, but without having to reinvent the
CombinedFormatLogger behavior (since it is non-public today).