### PR TITLE
Add method to StubClient verifying mappings

### DIFF
--- a/apollo-test/src/test/java/com/spotify/apollo/test/StubClientTest.java
+++ b/apollo-test/src/test/java/com/spotify/apollo/test/StubClientTest.java
@@ -364,4 +364,41 @@ public class StubClientTest {
     assertThat(getResponse("http://pingpong"),
                hasPayload(equalTo(ByteString.encodeUtf8("a game"))));
   }
+
+  @Test
+  public void verifyAllMappingsSentAssertsIfNoRequestSent() throws Exception {
+    stubClient.addMapping(uri("http://ping"), Response.ok());
+
+    exception.expect(AssertionError.class);
+    exception.expectMessage(containsString("uri matches \"http://ping\""));
+    stubClient.verifyAllMappingsSent();
+  }
+
+  @Test
+  public void verifyAllMappingsSentDoesNotThrowWithNoMappings() throws Exception {
+    stubClient.verifyAllMappingsSent();
+  }
+
+  @Test
+  public void verifyAllMappingsSentDoesNotThrowIfAllMappingsMatched() throws Exception {
+    stubClient.addMapping(uri("http://ping"), Response.ok());
+    stubClient.addMapping(uri("http://pong"), Response.ok());
+
+    stubClient.send(Request.forUri("http://ping"));
+    stubClient.send(Request.forUri("http://pong"));
+
+    stubClient.verifyAllMappingsSent();
+  }
+
+  @Test
+  public void verifyAllMappingsSentThrowsIfOnlySubsetSent() throws Exception {
+    stubClient.addMapping(uri("http://ping"), Response.ok());
+    stubClient.addMapping(uri("http://pong"), Response.ok());
+
+    stubClient.send(Request.forUri("http://pong"));
+
+    exception.expect(AssertionError.class);
+    exception.expectMessage(containsString("uri matches \"http://ping\""));
+    stubClient.verifyAllMappingsSent();
+  }
 }


### PR DESCRIPTION
This is a useful in unit tests to ensure that all requests were sent by
the stub client. In the case that a Request status isn't important, but
sending it is, such as a "fire-and-forget" scenario, this is nice to verify.

For example,

```java
stubClient.addMapping(uri("http://fire-and-forget"), ...);

...
// Ensure that all mappings sent
stubClient.verifyAllMappingsSent() // will assert everything was sent.
```

Previously this was achievable but was hacky

```java
stubClient.addMapping(uri("http://fire-and-forget"), ...);

...
// Ensure that all mappings sent
assertThat(stubClient.sentRequests(), contains(uri("http://fire-and-forget"));
// or...
assertThat(stubClient.sentRequests(), size(1));
```

This verification is simple, and does not handle sequenced ResponseSources
or checks that a match was made multiple times. But it is a good first step.