### PR TITLE
StubClient more details on no match

### DIFF
--- a/apollo-test/src/test/java/com/spotify/apollo/test/StubClientTest.java
+++ b/apollo-test/src/test/java/com/spotify/apollo/test/StubClientTest.java
@@ -247,6 +247,19 @@ public class StubClientTest {
   }
 
   @Test
+  public void noMatchingResponseFoundThrownIfNoMapping() throws Throwable {
+    stubClient.addMapping(uri("http://ping"), Response.ok());
+
+    exception.expect(isA(StubClient.NoMatchingResponseFoundException.class));
+    try {
+      getString("http://pong").toCompletableFuture().get();
+    } catch (ExecutionException ee) {
+      throw ee.getCause();
+    }
+    fail("should throw");
+  }
+
+  @Test
   public void shouldDisallowChangingDelayForResponseSource() throws Exception {
     StubClient.StubbedResponseBuilder builder = stubClient.respond(Responses.constant(HELLO_WORLD));
 


### PR DESCRIPTION
Today you don't get much details on what was not matched when
No match was found. However this can be confusing in testing,
as you never see what the cause of the mismatch was without debugging 
or trial/error.

This will detail the expected matchers.