### PR TITLE
Move jackson dependency out of apollo-core

### DIFF
--- a/apollo-core/pom.xml
+++ b/apollo-core/pom.xml
@@ -47,15 +47,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/modules/slack/pom.xml
+++ b/modules/slack/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>apollo-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
         </dependency>


### PR DESCRIPTION
Nothing in apollo-core is using jackson. However the slack module uses
it as a transitive dependency, so it needs to be readded there.