### PR TITLE
Look up headers in a case insensitive way

### DIFF
--- a/apollo-api-impl/src/test/java/com/spotify/apollo/request/RequestRunnableImplTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/request/RequestRunnableImplTest.java
@@ -36,6 +36,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -109,7 +110,8 @@ public class RequestRunnableImplTest {
     verify(ongoingRequest).reply(responseArgumentCaptor.capture());
     Response<ByteString> reply = responseArgumentCaptor.getValue();
     assertEquals(reply.status(), Status.METHOD_NOT_ALLOWED);
-    assertEquals(reply.headers(), Collections.singletonMap("Allow", "OPTIONS, POST"));
+    assertEquals(reply.headerEntries(),
+        Collections.singletonList(new SimpleEntry<>("Allow", "OPTIONS, POST")));
   }
 
   @Test
@@ -124,7 +126,8 @@ public class RequestRunnableImplTest {
     verify(ongoingRequest).reply(responseArgumentCaptor.capture());
     Response<ByteString> response = responseArgumentCaptor.getValue();
     assertThat(response.status(), is(Status.NO_CONTENT));
-    assertThat(response.headers(), is(Collections.singletonMap("Allow", "OPTIONS, POST")));
+    assertThat(response.headerEntries(),
+        is(Collections.singletonList(new SimpleEntry<>("Allow", "OPTIONS, POST"))));
   }
 
   @Test

--- a/apollo-api/src/main/java/com/spotify/apollo/Headers.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/Headers.java
@@ -1,0 +1,82 @@
+/*
+ * -\-\-
+ * Spotify Apollo API Interfaces
+ * --
+ * Copyright (C) 2013 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@AutoValue
+abstract class Headers {
+
+  static Headers EMPTY = create(Collections.emptyMap());
+
+  static Headers create(Map<String, String> headers) {
+    final List<Map.Entry<String, String>> headersList = new ArrayList<>(headers.size());
+    headers.entrySet().forEach(h -> insertIfAbsent(headersList, h));
+    return new AutoValue_Headers(ImmutableList.copyOf(headersList));
+  }
+
+  public Optional<String> get(String name) {
+    Preconditions.checkArgument(name != null, "Header names cannot be null");
+
+    for (int i = 0; i < entries().size(); i++) {
+      final Map.Entry<String, String> headerEntry = entries().get(i);
+      if (name.equalsIgnoreCase(headerEntry.getKey())) {
+        return Optional.ofNullable(headerEntry.getValue());
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  public Map<String, String> asMap() {
+    ImmutableMap.Builder<String, String> headers = ImmutableMap.builder();
+    entries().forEach(headers::put);
+    return headers.build();
+  }
+
+  public abstract ImmutableList<Map.Entry<String, String>> entries();
+
+  private static void insertIfAbsent(List<Map.Entry<String, String>> headerList,
+                                     Map.Entry<String, String> newHeader) {
+
+    // Replace existing header with new key (letter case can be overwritten) and value
+    for (int i = 0; i < headerList.size(); i++) {
+      Map.Entry<String, String> currentHeader = headerList.get(i);
+      if (currentHeader.getKey().equalsIgnoreCase(newHeader.getKey())) {
+        headerList.set(i, new SimpleImmutableEntry<>(newHeader));
+        return;
+      }
+    }
+
+    // No matching entry present, add new entry
+    headerList.add(new SimpleImmutableEntry<>(newHeader));
+  }
+
+}

--- a/apollo-api/src/main/java/com/spotify/apollo/Headers.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/Headers.java
@@ -20,7 +20,6 @@
 package com.spotify.apollo;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -29,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 @AutoValue
@@ -38,12 +38,12 @@ abstract class Headers {
 
   static Headers create(Map<String, String> headers) {
     final List<Map.Entry<String, String>> headersList = new ArrayList<>(headers.size());
-    headers.entrySet().forEach(h -> insertIfAbsent(headersList, h));
+    headers.entrySet().forEach(h -> insertOrReplace(headersList, h));
     return new AutoValue_Headers(ImmutableList.copyOf(headersList));
   }
 
   public Optional<String> get(String name) {
-    Preconditions.checkArgument(name != null, "Header names cannot be null");
+    Objects.requireNonNull(name, "Header names cannot be null");
 
     for (int i = 0; i < entries().size(); i++) {
       final Map.Entry<String, String> headerEntry = entries().get(i);
@@ -63,8 +63,8 @@ abstract class Headers {
 
   public abstract ImmutableList<Map.Entry<String, String>> entries();
 
-  private static void insertIfAbsent(List<Map.Entry<String, String>> headerList,
-                                     Map.Entry<String, String> newHeader) {
+  private static void insertOrReplace(List<Map.Entry<String, String>> headerList,
+                                      Map.Entry<String, String> newHeader) {
 
     // Replace existing header with new key (letter case can be overwritten) and value
     for (int i = 0; i < headerList.size(); i++) {

--- a/apollo-api/src/main/java/com/spotify/apollo/Request.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/Request.java
@@ -19,6 +19,8 @@
  */
 package com.spotify.apollo;
 
+import com.google.common.base.Preconditions;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -67,14 +69,31 @@ public interface Request {
 
   /**
    * The headers of the request message.
+   * Deprecated in favor of {@link Request#headerEntries()}
    */
+  @Deprecated
   Map<String, String> headers();
 
   /**
-   * A header of the request message, or empty if no header with that name is found.
+   * All the headers of the request message.
+   */
+  Iterable<Map.Entry<String, String>> headerEntries();
+
+
+  /**
+   * A header of the request message, looked up in a case insensitive way,
+   * or empty if no header with that name is found.
    */
   default Optional<String> header(String name) {
-    return Optional.ofNullable(headers().get(name));
+    Preconditions.checkArgument(name != null, "Header names cannot be null");
+
+    for (Map.Entry<String, String> headerEntry : headerEntries()) {
+      if (name.equalsIgnoreCase(headerEntry.getKey())) {
+        return Optional.ofNullable(headerEntry.getValue());
+      }
+    }
+
+    return Optional.empty();
   }
 
   /**

--- a/apollo-api/src/main/java/com/spotify/apollo/Request.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/Request.java
@@ -19,11 +19,10 @@
  */
 package com.spotify.apollo;
 
-import com.google.common.base.Preconditions;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import okio.ByteString;
@@ -77,7 +76,7 @@ public interface Request {
   /**
    * All the headers of the request message.
    */
-  Iterable<Map.Entry<String, String>> headerEntries();
+  List<Map.Entry<String, String>> headerEntries();
 
 
   /**
@@ -85,7 +84,7 @@ public interface Request {
    * or empty if no header with that name is found.
    */
   default Optional<String> header(String name) {
-    Preconditions.checkArgument(name != null, "Header names cannot be null");
+    Objects.requireNonNull(name, "Header names cannot be null");
 
     for (Map.Entry<String, String> headerEntry : headerEntries()) {
       if (name.equalsIgnoreCase(headerEntry.getKey())) {

--- a/apollo-api/src/main/java/com/spotify/apollo/RequestValue.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/RequestValue.java
@@ -74,7 +74,7 @@ abstract class RequestValue implements Request {
   }
 
   @Override
-  public Iterable<Map.Entry<String, String>> headerEntries() {
+  public List<Map.Entry<String, String>> headerEntries() {
     return internalHeadersImpl().entries();
   }
 

--- a/apollo-api/src/main/java/com/spotify/apollo/Response.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/Response.java
@@ -19,6 +19,8 @@
  */
 package com.spotify.apollo;
 
+import com.google.common.base.Preconditions;
+
 import java.util.Map;
 import java.util.Optional;
 
@@ -40,8 +42,31 @@ public interface Response<T> {
 
   /**
    * The response headers.
+   * Deprecated in favor of {@link Response#headerEntries()}
    */
+  @Deprecated
   Map<String, String> headers();
+
+  /**
+   * The response headers
+   */
+  Iterable<Map.Entry<String, String>> headerEntries();
+
+  /**
+   * A header of the request message, looked up in a case insensitive way,
+   * or empty if no header with that name is found.
+   */
+  default Optional<String> header(String name) {
+    Preconditions.checkArgument(name != null, "Header names cannot be null");
+
+    for (Map.Entry<String, String> headerEntry : headerEntries()) {
+      if (name.equalsIgnoreCase(headerEntry.getKey())) {
+        return Optional.ofNullable(headerEntry.getValue());
+      }
+    }
+
+    return Optional.empty();
+  }
 
   /**
    * The single payload of the response.
@@ -119,4 +144,5 @@ public interface Response<T> {
   static <T> Response<T> of(StatusType statusCode, T payload) {
     return ResponseImpl.create(statusCode, payload);
   }
+
 }

--- a/apollo-api/src/main/java/com/spotify/apollo/Response.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/Response.java
@@ -19,9 +19,9 @@
  */
 package com.spotify.apollo;
 
-import com.google.common.base.Preconditions;
-
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -50,14 +50,14 @@ public interface Response<T> {
   /**
    * The response headers
    */
-  Iterable<Map.Entry<String, String>> headerEntries();
+  List<Map.Entry<String, String>> headerEntries();
 
   /**
    * A header of the request message, looked up in a case insensitive way,
    * or empty if no header with that name is found.
    */
   default Optional<String> header(String name) {
-    Preconditions.checkArgument(name != null, "Header names cannot be null");
+    Objects.requireNonNull(name, "Header names cannot be null");
 
     for (Map.Entry<String, String> headerEntry : headerEntries()) {
       if (name.equalsIgnoreCase(headerEntry.getKey())) {
@@ -144,5 +144,4 @@ public interface Response<T> {
   static <T> Response<T> of(StatusType statusCode, T payload) {
     return ResponseImpl.create(statusCode, payload);
   }
-
 }

--- a/apollo-api/src/main/java/com/spotify/apollo/ResponseImpl.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/ResponseImpl.java
@@ -22,6 +22,7 @@ package com.spotify.apollo;
 import com.google.auto.value.AutoValue;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -45,7 +46,7 @@ abstract class ResponseImpl<T> implements Response<T> {
   }
 
   @Override
-  public Iterable<Map.Entry<String, String>> headerEntries() {
+  public List<Map.Entry<String, String>> headerEntries() {
     return internalHeadersImpl().entries();
   }
 

--- a/apollo-api/src/test/java/com/spotify/apollo/HeadersTest.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/HeadersTest.java
@@ -1,0 +1,157 @@
+/*
+ * -\-\-
+ * Spotify Apollo API Interfaces
+ * --
+ * Copyright (C) 2013 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HeadersTest {
+
+  private static final Map<String, String> TEST_MAP_DUPLICATE_KEYS = createDuplicateKeysMap();
+  private static final Map<String, String> TEST_BIG_MAP = createBigMap();
+
+  private static Map<String, String> createDuplicateKeysMap() {
+    LinkedHashMap<String, String> testMap = new LinkedHashMap<>(3);
+    testMap.put("first-key", "value1");
+    testMap.put("second-key", "other-value");
+    testMap.put("FirST-KEy", "value2");
+    return testMap;
+  }
+
+  private static Map<String, String> createBigMap() {
+    LinkedHashMap<String, String> testMap = new LinkedHashMap<>(100);
+    for (int i = 0; i < 100; i++) {
+      String number = String.valueOf(i);
+      testMap.put(number, number);
+    }
+    return testMap;
+  }
+
+  @Test
+  public void testGetIsCaseInsensitiveLower() {
+    Map<String, String> map = Collections.singletonMap("x-name", "value");
+    Headers headers = Headers.create(map);
+
+    assertThat(headers.get("X-NaMe"), is(Optional.of("value")));
+  }
+
+  @Test
+  public void testGetIsCaseInsensitiveUpper() {
+    Map<String, String> map = Collections.singletonMap("X-NAme", "value");
+    Headers headers = Headers.create(map);
+
+    assertThat(headers.get("x-name"), is(Optional.of("value")));
+  }
+
+  @Test
+  public void testAsMapPreservesOrderForOverwrittenKeys() {
+    Headers headers = Headers.create(TEST_MAP_DUPLICATE_KEYS);
+    ArrayList<Map.Entry<String, String>> asMapResult = new ArrayList<>(headers.asMap().entrySet());
+
+    assertThat(headers.asMap().size(), is(2));
+
+    // First key and value where overwritten, but kept on the same first position
+    assertThat(asMapResult.get(0).getKey(), is("FirST-KEy"));
+    assertThat(asMapResult.get(0).getValue(), is("value2"));
+
+    // Second header key and value stayed on the second position
+    assertThat(asMapResult.get(1).getKey(), is("second-key"));
+    assertThat(asMapResult.get(1).getValue(), is("other-value"));
+  }
+
+  @Test
+  public void testAsMapPreservesOrderFromConstructor() {
+    Headers headers = Headers.create(TEST_BIG_MAP);
+
+    ArrayList<Map.Entry<String, String>> asMapResult = new ArrayList<>(headers.asMap().entrySet());
+    assertThat(asMapResult.size(), is(TEST_BIG_MAP.size()));
+
+    for (int i = 0; i < asMapResult.size(); i++) {
+      Map.Entry<String, String> header = asMapResult.get(i);
+      assertThat(header.getKey(), is(String.valueOf(i)));
+    }
+  }
+
+  @Test
+  public void testAsMapPreservesLetterCase() {
+    Map<String, String> map = Collections.singletonMap("sTRangE-KEy", "value");
+    Headers headers = Headers.create(map);
+
+    Map.Entry<String, String> asMapResult = headers.asMap().entrySet().iterator().next();
+
+    assertThat(asMapResult.getKey(), is("sTRangE-KEy"));
+  }
+
+  @Test
+  public void testEntriesPreservesOrderForOverwrittenKeys() {
+    Headers headers = Headers.create(TEST_MAP_DUPLICATE_KEYS);
+
+    ArrayList<Map.Entry<String, String>> entriesResult = new ArrayList<>(headers.entries());
+
+    assertThat(headers.entries().size(), is(2));
+
+    // First key and value where overwritten, but kept on the same first position
+    assertThat(entriesResult.get(0).getKey(), is("FirST-KEy"));
+    assertThat(entriesResult.get(0).getValue(), is("value2"));
+
+    // Second header key and value stayed on the second position
+    assertThat(entriesResult.get(1).getKey(), is("second-key"));
+    assertThat(entriesResult.get(1).getValue(), is("other-value"));
+  }
+
+  @Test
+  public void testEntriesPreservesOrderFromConstructor() {
+    Headers headers = Headers.create(TEST_BIG_MAP);
+
+    ArrayList<Map.Entry<String, String>> entries = new ArrayList<>(headers.entries());
+    assertThat(entries.size(), is(TEST_BIG_MAP.size()));
+
+    for (int i = 0; i < entries.size(); i++) {
+      Map.Entry<String, String> header = entries.get(i);
+      assertThat(header.getKey(), is(String.valueOf(i)));
+    }
+  }
+
+  @Test
+  public void testEntriesPreservesLetterCase() {
+    Map<String, String> map = Collections.singletonMap("sTRangE-KEy", "value");
+    Headers headers = Headers.create(map);
+
+    Map.Entry<String, String> asMapResult = headers.entries().get(0);
+
+    assertThat(headers.entries().size(), is(1));
+    assertThat(asMapResult.getKey(), is("sTRangE-KEy"));
+  }
+
+  @Test
+  public void testEmptyConstructor() {
+    Headers headers = Headers.create(Collections.emptyMap());
+    assertThat(headers.asMap().size(), is(0));
+    assertThat(headers.get("non-existent"), is(Optional.empty()));
+  }
+}

--- a/apollo-api/src/test/java/com/spotify/apollo/HeadersTest.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/HeadersTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -36,7 +37,7 @@ public class HeadersTest {
   private static final Map<String, String> TEST_BIG_MAP = createBigMap();
 
   private static Map<String, String> createDuplicateKeysMap() {
-    LinkedHashMap<String, String> testMap = new LinkedHashMap<>(3);
+    Map<String, String> testMap = new LinkedHashMap<>(3);
     testMap.put("first-key", "value1");
     testMap.put("second-key", "other-value");
     testMap.put("FirST-KEy", "value2");
@@ -44,7 +45,7 @@ public class HeadersTest {
   }
 
   private static Map<String, String> createBigMap() {
-    LinkedHashMap<String, String> testMap = new LinkedHashMap<>(100);
+    Map<String, String> testMap = new LinkedHashMap<>(100);
     for (int i = 0; i < 100; i++) {
       String number = String.valueOf(i);
       testMap.put(number, number);
@@ -71,7 +72,7 @@ public class HeadersTest {
   @Test
   public void testAsMapPreservesOrderForOverwrittenKeys() {
     Headers headers = Headers.create(TEST_MAP_DUPLICATE_KEYS);
-    ArrayList<Map.Entry<String, String>> asMapResult = new ArrayList<>(headers.asMap().entrySet());
+    List<Map.Entry<String, String>> asMapResult = new ArrayList<>(headers.asMap().entrySet());
 
     assertThat(headers.asMap().size(), is(2));
 
@@ -88,7 +89,7 @@ public class HeadersTest {
   public void testAsMapPreservesOrderFromConstructor() {
     Headers headers = Headers.create(TEST_BIG_MAP);
 
-    ArrayList<Map.Entry<String, String>> asMapResult = new ArrayList<>(headers.asMap().entrySet());
+    List<Map.Entry<String, String>> asMapResult = new ArrayList<>(headers.asMap().entrySet());
     assertThat(asMapResult.size(), is(TEST_BIG_MAP.size()));
 
     for (int i = 0; i < asMapResult.size(); i++) {
@@ -111,7 +112,7 @@ public class HeadersTest {
   public void testEntriesPreservesOrderForOverwrittenKeys() {
     Headers headers = Headers.create(TEST_MAP_DUPLICATE_KEYS);
 
-    ArrayList<Map.Entry<String, String>> entriesResult = new ArrayList<>(headers.entries());
+    List<Map.Entry<String, String>> entriesResult = new ArrayList<>(headers.entries());
 
     assertThat(headers.entries().size(), is(2));
 
@@ -128,7 +129,7 @@ public class HeadersTest {
   public void testEntriesPreservesOrderFromConstructor() {
     Headers headers = Headers.create(TEST_BIG_MAP);
 
-    ArrayList<Map.Entry<String, String>> entries = new ArrayList<>(headers.entries());
+    List<Map.Entry<String, String>> entries = new ArrayList<>(headers.entries());
     assertThat(entries.size(), is(TEST_BIG_MAP.size()));
 
     for (int i = 0; i < entries.size(); i++) {

--- a/apollo-api/src/test/java/com/spotify/apollo/RequestTest.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/RequestTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -106,10 +107,10 @@ public class RequestTest {
 
   @Test
   public void shouldReturnHeadersPreservingLetterCase() throws Exception {
-    Iterable<Map.Entry<String, String>> headerEntries = requestWithHeader("/foo", "HEAder", "value")
+    List<Map.Entry<String, String>> headerEntries = requestWithHeader("/foo", "HEAder", "value")
         .headerEntries();
-    assertThat(headerEntries.iterator().next().getKey(),
-               is("HEAder"));
+    assertThat(headerEntries.size(), is(1));
+    assertThat(headerEntries.get(0).getKey(), is("HEAder"));
   }
 
   @Test

--- a/apollo-api/src/test/java/com/spotify/apollo/RequestTest.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/RequestTest.java
@@ -99,6 +99,20 @@ public class RequestTest {
   }
 
   @Test
+  public void shouldReturnHeaderCaseInsensitive() throws Exception {
+    assertThat(requestWithHeader("/foo", "hEaDEr", "value").header("HeadeR"),
+               is(Optional.of("value")));
+  }
+
+  @Test
+  public void shouldReturnHeadersPreservingLetterCase() throws Exception {
+    Iterable<Map.Entry<String, String>> headerEntries = requestWithHeader("/foo", "HEAder", "value")
+        .headerEntries();
+    assertThat(headerEntries.iterator().next().getKey(),
+               is("HEAder"));
+  }
+
+  @Test
   public void shouldReturnNoPayload() throws Exception {
     assertThat(request("/foo").payload(),
                is(Optional.empty()));

--- a/apollo-api/src/test/java/com/spotify/apollo/ResponseTest.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/ResponseTest.java
@@ -24,7 +24,10 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
 import java.util.Map;
+import java.util.Optional;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
@@ -38,7 +41,7 @@ public class ResponseTest {
         .withHeader("Content-Type", "application/json")
         .withHeader("Content-Type", "application/protobuf");
 
-    assertEquals("application/protobuf", response.headers().get("Content-Type"));
+    assertEquals(Optional.of("application/protobuf"), response.header("Content-Type"));
   }
 
   @Test
@@ -52,9 +55,39 @@ public class ResponseTest {
         .withHeader("Content-Type", "application/json")
         .withHeaders(headers);
 
-    assertEquals("application/protobuf", response.headers().get("Content-Type"));
-    assertEquals("123", response.headers().get("Content-Length"));
+    assertEquals(Optional.of("application/protobuf"), response.header("Content-Type"));
+    assertEquals(Optional.of("123"), response.header("Content-Length"));
+  }
 
+  @Test
+  public void shouldReturnHeaderCaseInsensitive() throws Exception {
+    assertThat(Response.ok().withHeader("hEaDEr", "value").header("HeadeR"),
+        is(Optional.of("value")));
+  }
+
+  @Test
+  public void shouldReturnHeaderEntriesPreservingLetterCase() throws Exception {
+    Iterable<Map.Entry<String, String>> headerEntries = Response.ok().withHeader("HEAder", "value")
+        .headerEntries();
+    assertThat(headerEntries.iterator().next().getKey(),
+        is("HEAder"));
+  }
+
+  @Test
+  public void shouldReturnHeadersMapPreservingLetterCase() throws Exception {
+    Map<String, String> headers = Response.ok().withHeader("HEAder", "value").headers();
+
+    assertThat(headers.get("HEAder"), is("value"));
+  }
+
+  @Test
+  public void allowsOverrideHeaderValuesInHeadersMap() {
+    Response<?> response = Response
+        .forStatus(Status.OK)
+        .withHeader("Content-Type", "application/json")
+        .withHeader("Content-Type", "application/protobuf");
+
+    assertEquals("application/protobuf", response.headers().get("Content-Type"));
   }
 
   @Test

--- a/apollo-api/src/test/java/com/spotify/apollo/ResponseTest.java
+++ b/apollo-api/src/test/java/com/spotify/apollo/ResponseTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -67,9 +68,10 @@ public class ResponseTest {
 
   @Test
   public void shouldReturnHeaderEntriesPreservingLetterCase() throws Exception {
-    Iterable<Map.Entry<String, String>> headerEntries = Response.ok().withHeader("HEAder", "value")
+    List<Map.Entry<String, String>> headerEntries = Response.ok().withHeader("HEAder", "value")
         .headerEntries();
-    assertThat(headerEntries.iterator().next().getKey(),
+    assertThat(headerEntries.size(), is(1));
+    assertThat(headerEntries.get(0).getKey(),
         is("HEAder"));
   }
 

--- a/apollo-extra/src/test/java/com/spotify/apollo/route/HtmlSerializerMiddlewaresTest.java
+++ b/apollo-extra/src/test/java/com/spotify/apollo/route/HtmlSerializerMiddlewaresTest.java
@@ -81,7 +81,7 @@ public class HtmlSerializerMiddlewaresTest {
 
   private void checkContentTypeAndBody(final Response<ByteString> response) {
     assertEquals("<html>yo</html>\n", response.payload().get().utf8());
-    assertEquals("text/html; charset=UTF8", response.headers().get("Content-Type"));
+    assertEquals("text/html; charset=UTF8", response.header("Content-Type").get());
   }
 
 }

--- a/apollo-extra/src/test/java/com/spotify/apollo/route/JsonSerializerMiddlewaresTest.java
+++ b/apollo-extra/src/test/java/com/spotify/apollo/route/JsonSerializerMiddlewaresTest.java
@@ -26,9 +26,9 @@ import com.spotify.apollo.Status;
 
 import org.junit.Test;
 
-import okio.ByteString;
-
 import java.util.Optional;
+
+import okio.ByteString;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -46,7 +46,7 @@ public class JsonSerializerMiddlewaresTest {
   }
 
   private static void checkContentType(Response<ByteString> response) {
-    assertThat(response.headers().get("Content-Type"), equalTo("application/json; charset=UTF8"));
+    assertThat(response.header("Content-Type").get(), equalTo("application/json; charset=UTF8"));
   }
 
   @Test

--- a/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/acceptance/RequestStepdefs.java
+++ b/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/acceptance/RequestStepdefs.java
@@ -97,7 +97,7 @@ public class RequestStepdefs {
   public void the_response_has_a_header_with_value(String headerName, String expectedValue) throws Throwable {
     Response<ByteString> response = getResponseFuture();
 
-    assertThat(response.headers().get(headerName), equalTo(expectedValue));
+    assertThat(response.header(headerName).get(), equalTo(expectedValue));
   }
 
   @And("^the reason phrase is \"([^\"]*)\"$")

--- a/apollo-test/src/main/java/com/spotify/apollo/test/unit/ResponseMatchers.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/unit/ResponseMatchers.java
@@ -46,7 +46,7 @@ public final class ResponseMatchers {
     return new TypeSafeMatcher<Response<T>>() {
       @Override
       protected boolean matchesSafely(Response<T> item) {
-        return item.headers().isEmpty();
+        return !item.headerEntries().iterator().hasNext();
       }
 
       @Override
@@ -56,7 +56,7 @@ public final class ResponseMatchers {
 
       @Override
       protected void describeMismatchSafely(Response<T> item, Description mismatchDescription) {
-        mismatchDescription.appendText("it contained headers ").appendValue(item.headers());
+        mismatchDescription.appendText("it contained headers ").appendValue(item.headerEntries());
       }
     };
   }
@@ -74,7 +74,7 @@ public final class ResponseMatchers {
 
       @Override
       protected String featureValueOf(Response<T> actual) {
-        return actual.headers().get(header);
+        return actual.header(header).orElse(null);
       }
     };
   }
@@ -88,7 +88,7 @@ public final class ResponseMatchers {
     return new TypeSafeMatcher<Response<T>>() {
       @Override
       protected boolean matchesSafely(Response<T> item) {
-        return item.headers().get(header) == null;
+        return !item.header(header).isPresent();
       }
 
       @Override
@@ -99,7 +99,7 @@ public final class ResponseMatchers {
       @Override
       protected void describeMismatchSafely(Response<T> item, Description mismatchDescription) {
         mismatchDescription.appendText("it contained the header ");
-        mismatchDescription.appendValueList("{", ":", "}", header, item.headers().get(header));
+        mismatchDescription.appendValueList("{", ":", "}", header, item.header(header));
       }
 
     };

--- a/apollo-test/src/test/java/com/spotify/apollo/test/StubClientTest.java
+++ b/apollo-test/src/test/java/com/spotify/apollo/test/StubClientTest.java
@@ -253,11 +253,11 @@ public class StubClientTest {
   @Test
   public void shouldSupportHeadersForResponses() throws Exception {
     stubClient.respond(Response.<ByteString>ok()
-                           .withHeader("foo", "bar"))
+        .withHeader("foo", "bar"))
         .to("http://ping");
 
     Response reply = getResponse("http://ping").toCompletableFuture().get();
-    assertThat(reply.headers().get("foo"), equalTo("bar"));
+    assertThat(reply.header("foo").get(), equalTo("bar"));
   }
 
   @Test

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/AsyncContextOngoingRequest.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/AsyncContextOngoingRequest.java
@@ -91,7 +91,8 @@ class AsyncContextOngoingRequest implements OngoingRequest {
       final StatusType status = response.status();
       httpResponse.setStatus(status.code(), status.reasonPhrase());
 
-      response.headers().forEach(httpResponse::addHeader);
+      response.headerEntries().forEach(entry ->
+          httpResponse.addHeader(entry.getKey(), entry.getValue()));
 
       response.payload().ifPresent(payload -> {
         try {

--- a/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClient.java
+++ b/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClient.java
@@ -74,7 +74,7 @@ class HttpClient implements IncomingRequestAwareClient {
     });
 
     Headers.Builder headersBuilder = new Headers.Builder();
-    apolloRequest.headers().forEach((k, v) -> headersBuilder.add(k, v));
+    apolloRequest.headerEntries().forEach((e) -> headersBuilder.add(e.getKey(), e.getValue()));
 
     apolloIncomingRequest
         .flatMap(req -> req.header(AUTHORIZATION_HEADER))

--- a/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/HttpClientTest.java
+++ b/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/HttpClientTest.java
@@ -34,6 +34,7 @@ import org.mockserver.junit.MockServerRule;
 
 import java.net.SocketTimeoutException;
 import java.time.Duration;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Optional;
 
 import okio.ByteString;
@@ -41,9 +42,9 @@ import okio.ByteString;
 import static java.lang.String.format;
 import static java.util.Optional.empty;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockserver.model.HttpCallback.callback;
@@ -104,7 +105,7 @@ public class HttpClientTest {
         .toCompletableFuture().get();
 
     assertThat(response.status(), withCode(200));
-    assertThat(response.headers().get("x-got-the-special-header"), equalTo("yup"));
+    assertThat(response.header("x-got-the-special-header").get(), equalTo("yup"));
   }
 
   @Test
@@ -136,9 +137,9 @@ public class HttpClientTest {
         .toCompletableFuture().get();
 
     assertThat(response.status(), withCode(200));
-    assertThat(response.headers(), allOf(
-                   hasEntry("Content-Type", "application/x-spotify-location"),
-                   hasEntry("Vary", "Content-Type, Accept")
+    assertThat(response.headerEntries(), allOf(
+                   hasItem(new SimpleEntry<>("Content-Type", "application/x-spotify-location")),
+                   hasItem(new SimpleEntry<>("Vary", "Content-Type, Accept"))
                ));
     assertThat(response.payload(), is(Optional.of(ByteString.encodeUtf8("world"))));
   }
@@ -203,7 +204,7 @@ public class HttpClientTest {
         .send(request, Optional.of(originalRequest))
         .toCompletableFuture().get();
 
-    assertThat(response.headers().get("x-auth-was-fine"), equalTo("yes"));
+    assertThat(response.header("x-auth-was-fine").get(), equalTo("yes"));
   }
 
   @Test


### PR DESCRIPTION
In this first step apollo will look up headers in a case insensitive way but it will still preserve the original letter case of header fields when propagated. This makes services compatible with services that send lowercase headers (like those who propagate headers from an HTTP 2 connection). 

I recommend looking at the commits separately.

@pettermahlen @rouzwawi 