### PR TITLE
Read X-Calling-Service header in a case insensitive way

### DIFF
--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/ApolloRequestHandler.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/ApolloRequestHandler.java
@@ -48,7 +48,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import okio.ByteString;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
@@ -125,9 +124,9 @@ class ApolloRequestHandler extends AbstractHandler {
     Request result = Request.forUri(uri, method)
         .withHeaders(headers);
 
-    final String callingService = headers.get("X-Calling-Service");
-    if (!isNullOrEmpty(callingService)) {
-      result = result.withService(callingService);
+    final Optional<String> callingService = result.header("X-Calling-Service");
+    if (callingService.isPresent() && !callingService.get().isEmpty()) {
+      result = result.withService(callingService.get());
     }
 
     if (payload.isPresent()) {

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/ApolloRequestHandlerTest.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/ApolloRequestHandlerTest.java
@@ -56,7 +56,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -162,6 +161,16 @@ public class ApolloRequestHandlerTest {
     httpServletRequest = mockRequest("PUT",
                                      "http://somehost/a/b?q=abc&b=adf&q=def",
                                      ImmutableMap.of("X-Calling-Service", "testservice"));
+
+    assertThat(requestHandler.asApolloRequest(httpServletRequest).service(),
+               is(Optional.of("testservice")));
+  }
+
+  @Test
+  public void shouldExtractCallingServiceFromHeaderLowerCase() throws Exception {
+    httpServletRequest = mockRequest("PUT",
+                                     "http://somehost/a/b?q=abc&b=adf&q=def",
+                                     ImmutableMap.of("x-calling-service", "testservice"));
 
     assertThat(requestHandler.asApolloRequest(httpServletRequest).service(),
                is(Optional.of("testservice")));


### PR DESCRIPTION
@kouKatsumi 

By using the method  `Request.header(String headerName)` instead of a lookup in the map we get case insensitive lookup of that header.