### PR TITLE
Remove application-version from Metrics

### DIFF
--- a/apollo-http-service/src/main/java/com/spotify/apollo/httpservice/MetricIdModule.java
+++ b/apollo-http-service/src/main/java/com/spotify/apollo/httpservice/MetricIdModule.java
@@ -51,8 +51,7 @@ class MetricIdModule extends AbstractApolloModule {
     return MetricId.build("apollo").tagged(
         "service-framework", "http-service",
         "service-framework-version", metaDescriptor.apolloVersion(),
-        "application", metaDescriptor.descriptor().serviceName(),
-        "application-version", metaDescriptor.descriptor().version());
+        "application", metaDescriptor.descriptor().serviceName());
   }
 
   @Override


### PR DESCRIPTION
Merging this to the 1.x branch per the slack discussion. 

https://github.com/spotify/apollo/pull/189 was merged into master which is for the 2.x release.

\cc @martina-if 