### PR TITLE
Bump to version 1.5.0

### DIFF
--- a/apollo-api-impl/pom.xml
+++ b/apollo-api-impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.spotify</groupId>
         <artifactId>apollo-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <name>Spotify Apollo API Implementations</name>
@@ -17,7 +17,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-bom</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/meta/MetaDescriptorTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/meta/MetaDescriptorTest.java
@@ -32,6 +32,6 @@ public class MetaDescriptorTest {
   public void testLoadApolloVersion() throws Exception {
     ClassLoader classLoader = ClassLoader.getSystemClassLoader();
     String version = MetaDescriptor.loadApolloVersion(classLoader);
-    assertTrue(version.startsWith("1.4"));
+    assertTrue(version.startsWith("1.5"));
   }
 }

--- a/apollo-api/pom.xml
+++ b/apollo-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.spotify</groupId>
         <artifactId>apollo-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <name>Spotify Apollo API Interfaces</name>
@@ -17,7 +17,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-bom</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/apollo-bom/pom.xml
+++ b/apollo-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.spotify</groupId>
         <artifactId>apollo-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <name>Spotify Apollo Bill of Materials</name>
@@ -24,71 +24,71 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-core</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
 
             <!-- modules -->
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-okhttp-client</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-jetty-http-server</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-slack</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
 
             <!-- api & http service -->
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-api</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-api-impl</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-environment</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-route</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-extra</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-entity</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-metrics</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-http-service</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-test</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/apollo-core/pom.xml
+++ b/apollo-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.spotify</groupId>
         <artifactId>apollo-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <name>Spotify Apollo Service Core (aka Leto)</name>
@@ -17,7 +17,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-bom</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/apollo-entity/pom.xml
+++ b/apollo-entity/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.spotify</groupId>
         <artifactId>apollo-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -17,7 +17,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-bom</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/apollo-environment/pom.xml
+++ b/apollo-environment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.spotify</groupId>
         <artifactId>apollo-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -18,7 +18,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-bom</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/apollo-extra/pom.xml
+++ b/apollo-extra/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.spotify</groupId>
         <artifactId>apollo-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <name>Spotify Apollo Extra</name>
@@ -17,7 +17,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-bom</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/apollo-http-service/pom.xml
+++ b/apollo-http-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.spotify</groupId>
         <artifactId>apollo-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <name>Spotify Apollo HTTP Service</name>
@@ -17,7 +17,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-bom</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/apollo-route/pom.xml
+++ b/apollo-route/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.spotify</groupId>
         <artifactId>apollo-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <name>Spotify Apollo Route</name>
@@ -17,7 +17,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-bom</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/apollo-test/pom.xml
+++ b/apollo-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.spotify</groupId>
         <artifactId>apollo-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <name>Spotify Apollo Testing Helpers</name>
@@ -17,7 +17,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-bom</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/modules/jetty-http-server/pom.xml
+++ b/modules/jetty-http-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.spotify</groupId>
         <artifactId>apollo-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -18,7 +18,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-bom</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/modules/metrics/pom.xml
+++ b/modules/metrics/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.spotify</groupId>
         <artifactId>apollo-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -22,7 +22,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-bom</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/modules/okhttp-client/pom.xml
+++ b/modules/okhttp-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apollo-parent</artifactId>
         <groupId>com.spotify</groupId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -18,7 +18,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-bom</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/modules/slack/pom.xml
+++ b/modules/slack/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.spotify</groupId>
         <artifactId>apollo-parent</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -18,7 +18,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>apollo-bom</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>apollo-parent</artifactId>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <description>Java libraries for writing composable microservices</description>


### PR DESCRIPTION
@kouKatsumi @jpettersson 

This bumps first the version to the 1.5 snapshot. Then I can do the release. Note that there is a test that protects version bumping without a explicit commit for bumping the version.