### PR TITLE
upgrade to okhttp3

### DIFF
--- a/apollo-bom/pom.xml
+++ b/apollo-bom/pom.xml
@@ -97,14 +97,14 @@
             </dependency>
 
             <dependency>
-                <groupId>com.squareup.okhttp</groupId>
+                <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp</artifactId>
-                <version>2.5.0</version>
+                <version>3.9.0</version>
             </dependency>
             <dependency>
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio</artifactId>
-                <version>1.6.0</version>
+                <version>1.13.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>

--- a/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/HttpServiceTest.java
+++ b/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/HttpServiceTest.java
@@ -19,13 +19,6 @@
  */
 package com.spotify.apollo.httpservice;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
 import com.spotify.apollo.AppInit;
 import com.spotify.apollo.Environment;
 import com.spotify.apollo.RequestMetadata;
@@ -34,6 +27,12 @@ import com.spotify.apollo.core.Service;
 import com.spotify.apollo.http.server.HttpRequestMetadata;
 import com.spotify.apollo.route.AsyncHandler;
 import com.spotify.apollo.route.Route;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -42,13 +41,17 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okio.ByteString;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class HttpServiceTest {
 

--- a/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/HttpServiceTest.java
+++ b/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/HttpServiceTest.java
@@ -19,6 +19,13 @@
  */
 package com.spotify.apollo.httpservice;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
 import com.spotify.apollo.AppInit;
 import com.spotify.apollo.Environment;
 import com.spotify.apollo.RequestMetadata;
@@ -27,14 +34,6 @@ import com.spotify.apollo.core.Service;
 import com.spotify.apollo.http.server.HttpRequestMetadata;
 import com.spotify.apollo.route.AsyncHandler;
 import com.spotify.apollo.route.Route;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -43,15 +42,13 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
 import okio.ByteString;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class HttpServiceTest {
 

--- a/modules/jetty-http-server/pom.xml
+++ b/modules/jetty-http-server/pom.xml
@@ -61,7 +61,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp</groupId>
+            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <scope>test</scope>
         </dependency>

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerModuleTest.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerModuleTest.java
@@ -19,28 +19,6 @@
  */
 package com.spotify.apollo.http.server;
 
-import com.google.common.collect.Lists;
-
-import com.spotify.apollo.Response;
-import com.spotify.apollo.core.Service;
-import com.spotify.apollo.core.Services;
-import com.spotify.apollo.request.OngoingRequest;
-import com.spotify.apollo.request.RequestHandler;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import java.io.IOException;
-import java.net.ConnectException;
-import java.net.Socket;
-import java.util.List;
-import java.util.Optional;
-
 import static com.spotify.apollo.Status.IM_A_TEAPOT;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
@@ -49,6 +27,25 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import com.google.common.collect.Lists;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.core.Service;
+import com.spotify.apollo.core.Services;
+import com.spotify.apollo.request.OngoingRequest;
+import com.spotify.apollo.request.RequestHandler;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.Socket;
+import java.util.List;
+import java.util.Optional;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class HttpServerModuleTest {
 
@@ -75,7 +72,7 @@ public class HttpServerModuleTest {
           .url(baseUrl(port) + "/hello/world")
           .build();
 
-      com.squareup.okhttp.Response response = okHttpClient.newCall(request).execute();
+      okhttp3.Response response = okHttpClient.newCall(request).execute();
       assertThat(response.code(), is(IM_A_TEAPOT.code()));
 
       assertThat(testHandler.requests.size(), is(1));
@@ -100,7 +97,7 @@ public class HttpServerModuleTest {
           .url(baseUrl(port) + "/query?a=foo&b=bar&b=baz")
           .build();
 
-      com.squareup.okhttp.Response response = okHttpClient.newCall(httpRequest).execute();
+      okhttp3.Response response = okHttpClient.newCall(httpRequest).execute();
       assertThat(response.code(), is(IM_A_TEAPOT.code()));
 
       assertThat(testHandler.requests.size(), is(1));
@@ -129,7 +126,7 @@ public class HttpServerModuleTest {
           .addHeader("Repeat", "twice")
           .build();
 
-      com.squareup.okhttp.Response response = okHttpClient.newCall(httpRequest).execute();
+      okhttp3.Response response = okHttpClient.newCall(httpRequest).execute();
       assertThat(response.code(), is(IM_A_TEAPOT.code()));
 
       assertThat(testHandler.requests.size(), is(1));

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerModuleTest.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerModuleTest.java
@@ -19,6 +19,29 @@
  */
 package com.spotify.apollo.http.server;
 
+import com.google.common.collect.Lists;
+
+import com.spotify.apollo.Response;
+import com.spotify.apollo.core.Service;
+import com.spotify.apollo.core.Services;
+import com.spotify.apollo.request.OngoingRequest;
+import com.spotify.apollo.request.RequestHandler;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.Socket;
+import java.util.List;
+import java.util.Optional;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+
 import static com.spotify.apollo.Status.IM_A_TEAPOT;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
@@ -27,25 +50,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import com.google.common.collect.Lists;
-import com.spotify.apollo.Response;
-import com.spotify.apollo.core.Service;
-import com.spotify.apollo.core.Services;
-import com.spotify.apollo.request.OngoingRequest;
-import com.spotify.apollo.request.RequestHandler;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import java.io.IOException;
-import java.net.ConnectException;
-import java.net.Socket;
-import java.util.List;
-import java.util.Optional;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class HttpServerModuleTest {
 

--- a/modules/okhttp-client/pom.xml
+++ b/modules/okhttp-client/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>apollo-environment</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp</groupId>
+            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
         <dependency>

--- a/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClient.java
+++ b/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClient.java
@@ -21,12 +21,6 @@ package com.spotify.apollo.http.client;
 
 import com.spotify.apollo.environment.IncomingRequestAwareClient;
 
-import okhttp3.Headers;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -34,6 +28,11 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
 import okio.ByteString;
 
 class HttpClient implements IncomingRequestAwareClient {

--- a/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClient.java
+++ b/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClient.java
@@ -21,11 +21,11 @@ package com.spotify.apollo.http.client;
 
 import com.spotify.apollo.environment.IncomingRequestAwareClient;
 
-import com.squareup.okhttp.Headers;
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -90,11 +90,14 @@ class HttpClient implements IncomingRequestAwareClient {
         new CompletableFuture<>();
 
     //https://github.com/square/okhttp/wiki/Recipes#per-call-configuration
-    OkHttpClient finalClient = client;
+    final OkHttpClient finalClient;
     if (apolloRequest.ttl().isPresent()
-        && client.getReadTimeout() != apolloRequest.ttl().get().toMillis()) {
-      finalClient = client.clone();
-      finalClient.setReadTimeout(apolloRequest.ttl().get().toMillis(), TimeUnit.MILLISECONDS);
+        && client.readTimeoutMillis() != apolloRequest.ttl().get().toMillis()) {
+      finalClient = client.newBuilder()
+          .readTimeout(apolloRequest.ttl().get().toMillis(), TimeUnit.MILLISECONDS)
+          .build();
+    } else {
+      finalClient = client;
     }
 
     finalClient.newCall(request).enqueue(TransformingCallback.create(result));

--- a/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClientModule.java
+++ b/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClientModule.java
@@ -25,7 +25,7 @@ import com.spotify.apollo.module.AbstractApolloModule;
 import com.spotify.apollo.module.ApolloModule;
 
 import com.google.inject.multibindings.Multibinder;
-import com.squareup.okhttp.OkHttpClient;
+import okhttp3.OkHttpClient;
 
 public class HttpClientModule extends AbstractApolloModule {
 

--- a/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/OkHttpClientProvider.java
+++ b/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/OkHttpClientProvider.java
@@ -19,18 +19,21 @@
  */
 package com.spotify.apollo.http.client;
 
-import static com.spotify.apollo.environment.ConfigUtil.optionalBoolean;
-import static com.spotify.apollo.environment.ConfigUtil.optionalInt;
-
 import com.google.common.io.Closer;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+
 import com.spotify.apollo.concurrent.ExecutorServiceCloser;
 import com.typesafe.config.Config;
+
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+
 import okhttp3.ConnectionPool;
 import okhttp3.OkHttpClient;
+
+import static com.spotify.apollo.environment.ConfigUtil.optionalBoolean;
+import static com.spotify.apollo.environment.ConfigUtil.optionalInt;
 
 class OkHttpClientProvider implements Provider<OkHttpClient> {
 

--- a/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/OkHttpClientProvider.java
+++ b/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/OkHttpClientProvider.java
@@ -19,20 +19,18 @@
  */
 package com.spotify.apollo.http.client;
 
+import static com.spotify.apollo.environment.ConfigUtil.optionalBoolean;
+import static com.spotify.apollo.environment.ConfigUtil.optionalInt;
+
 import com.google.common.io.Closer;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-
 import com.spotify.apollo.concurrent.ExecutorServiceCloser;
-import com.squareup.okhttp.ConnectionPool;
-import com.squareup.okhttp.OkHttpClient;
 import com.typesafe.config.Config;
-
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-
-import static com.spotify.apollo.environment.ConfigUtil.optionalBoolean;
-import static com.spotify.apollo.environment.ConfigUtil.optionalInt;
+import okhttp3.ConnectionPool;
+import okhttp3.OkHttpClient;
 
 class OkHttpClientProvider implements Provider<OkHttpClient> {
 
@@ -47,34 +45,37 @@ class OkHttpClientProvider implements Provider<OkHttpClient> {
 
   @Override
   public OkHttpClient get() {
-    final OkHttpClient client = new OkHttpClient();
+    final OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
 
     //timeouts settings
     config.connectTimeoutMillis().ifPresent(
-        millis -> client.setConnectTimeout(millis, TimeUnit.MILLISECONDS));
+        millis -> clientBuilder.connectTimeout(millis, TimeUnit.MILLISECONDS));
 
     config.readTimeoutMillis().ifPresent(
-        millis -> client.setReadTimeout(millis, TimeUnit.MILLISECONDS));
+        millis -> clientBuilder.readTimeout(millis, TimeUnit.MILLISECONDS));
 
     config.writeTimeoutMillis().ifPresent(
-        millis -> client.setWriteTimeout(millis, TimeUnit.MILLISECONDS));
+        millis -> clientBuilder.writeTimeout(millis, TimeUnit.MILLISECONDS));
 
     // connection pool settings
-    client.setConnectionPool(new ConnectionPool(
+    clientBuilder.connectionPool(new ConnectionPool(
         // defaults that come from com.squareup.okhttp.ConnectionPool
         config.maxIdleConnections().orElse(5),
-        config.connectionKeepAliveDurationMillis().orElse(5 * 60 * 1000)
+        config.connectionKeepAliveDurationMillis().orElse(5 * 60 * 1000),
+        TimeUnit.MILLISECONDS
     ));
 
+    config.followRedirects().ifPresent(clientBuilder::followRedirects);
+
+    final OkHttpClient client = clientBuilder.build();
+
     // async dispatcher settings
-    config.maxAsyncRequests().ifPresent(max -> client.getDispatcher().setMaxRequests(max));
+    config.maxAsyncRequests().ifPresent(max -> client.dispatcher().setMaxRequests(max));
 
     config.maxAsyncRequestsPerHost().ifPresent(
-        max -> client.getDispatcher().setMaxRequestsPerHost(max));
+        max -> client.dispatcher().setMaxRequestsPerHost(max));
 
-    config.followRedirects().ifPresent(client::setFollowRedirects);
-
-    closer.register(ExecutorServiceCloser.of(client.getDispatcher().getExecutorService()));
+    closer.register(ExecutorServiceCloser.of(client.dispatcher().executorService()));
 
     return client;
   }

--- a/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/TransformingCallback.java
+++ b/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/TransformingCallback.java
@@ -20,20 +20,17 @@
 package com.spotify.apollo.http.client;
 
 import com.google.common.base.Joiner;
-
 import com.spotify.apollo.Response;
 import com.spotify.apollo.Status;
 import com.spotify.apollo.StatusType;
-import com.squareup.okhttp.Callback;
-import com.squareup.okhttp.Request;
-
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-
+import okhttp3.Call;
+import okhttp3.Callback;
 import okio.ByteString;
 
 class TransformingCallback implements Callback {
@@ -52,18 +49,18 @@ class TransformingCallback implements Callback {
   }
 
   @Override
-  public void onFailure(Request request, IOException e) {
-    final String message = MessageFormat.format("Request {0} failed", request);
+  public void onFailure(Call call, IOException e) {
+    final String message = MessageFormat.format("Request {0} failed", call.request());
     final IOException exception = new IOException(message, e);
     future.completeExceptionally(exception);
   }
 
   @Override
-  public void onResponse(com.squareup.okhttp.Response response) throws IOException {
+  public void onResponse(Call call, okhttp3.Response response) throws IOException {
     future.complete(transformResponse(response));
   }
 
-  static Response<ByteString> transformResponse(com.squareup.okhttp.Response response)
+  static Response<ByteString> transformResponse(okhttp3.Response response)
       throws IOException {
 
     final StatusType status =

--- a/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/TransformingCallback.java
+++ b/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/TransformingCallback.java
@@ -20,15 +20,18 @@
 package com.spotify.apollo.http.client;
 
 import com.google.common.base.Joiner;
+
 import com.spotify.apollo.Response;
 import com.spotify.apollo.Status;
 import com.spotify.apollo.StatusType;
+
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+
 import okhttp3.Call;
 import okhttp3.Callback;
 import okio.ByteString;

--- a/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/HttpClientModuleTest.java
+++ b/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/HttpClientModuleTest.java
@@ -19,24 +19,21 @@
  */
 package com.spotify.apollo.http.client;
 
-import com.spotify.apollo.core.Service;
-import com.spotify.apollo.core.Services;
-import com.spotify.apollo.environment.ClientDecorator;
-
-import com.google.inject.Injector;
-import com.google.inject.Key;
-import com.squareup.okhttp.OkHttpClient;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-
-import org.junit.Test;
-
-import java.util.Set;
-
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.spotify.apollo.core.Service;
+import com.spotify.apollo.core.Services;
+import com.spotify.apollo.environment.ClientDecorator;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.Set;
+import okhttp3.OkHttpClient;
+import org.junit.Test;
 
 public class HttpClientModuleTest {
 
@@ -72,7 +69,7 @@ public class HttpClientModuleTest {
     try (Service.Instance i = service.start(new String[] {}, config)) {
 
       final OkHttpClient underlying = i.resolve(OkHttpClient.class);
-      assertThat(underlying.getConnectTimeout(), is(7982));
+      assertThat(underlying.connectTimeoutMillis(), is(7982));
     }
 
   }

--- a/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/HttpClientModuleTest.java
+++ b/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/HttpClientModuleTest.java
@@ -19,21 +19,25 @@
  */
 package com.spotify.apollo.http.client;
 
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
 import com.google.inject.Injector;
 import com.google.inject.Key;
+
 import com.spotify.apollo.core.Service;
 import com.spotify.apollo.core.Services;
 import com.spotify.apollo.environment.ClientDecorator;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import java.util.Set;
-import okhttp3.OkHttpClient;
+
 import org.junit.Test;
+
+import java.util.Set;
+
+import okhttp3.OkHttpClient;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 public class HttpClientModuleTest {
 

--- a/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/OkHttpClientProviderTest.java
+++ b/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/OkHttpClientProviderTest.java
@@ -19,13 +19,16 @@
  */
 package com.spotify.apollo.http.client;
 
-import static org.junit.Assert.assertEquals;
-
 import com.google.common.io.Closer;
+
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import okhttp3.OkHttpClient;
+
 import org.junit.Test;
+
+import okhttp3.OkHttpClient;
+
+import static org.junit.Assert.assertEquals;
 
 public class OkHttpClientProviderTest {
 

--- a/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/OkHttpClientProviderTest.java
+++ b/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/OkHttpClientProviderTest.java
@@ -19,15 +19,13 @@
  */
 package com.spotify.apollo.http.client;
 
-import com.google.common.io.Closer;
+import static org.junit.Assert.assertEquals;
 
-import com.squareup.okhttp.OkHttpClient;
+import com.google.common.io.Closer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-
+import okhttp3.OkHttpClient;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class OkHttpClientProviderTest {
 
@@ -40,34 +38,34 @@ public class OkHttpClientProviderTest {
 
   @Test
   public void testConnectTimeout() {
-    assertEquals(1234, buildClient("http.client.connectTimeout: 1234").getConnectTimeout());
+    assertEquals(1234, buildClient("http.client.connectTimeout: 1234").connectTimeoutMillis());
   }
 
   @Test
   public void testReadTimeout() {
-    assertEquals(444, buildClient("http.client.readTimeout: 444").getReadTimeout());
+    assertEquals(444, buildClient("http.client.readTimeout: 444").readTimeoutMillis());
   }
 
   @Test
   public void testWriteTimeout() {
-    assertEquals(5555, buildClient("http.client.writeTimeout: 5555").getWriteTimeout());
+    assertEquals(5555, buildClient("http.client.writeTimeout: 5555").writeTimeoutMillis());
   }
 
   @Test
   public void testMaxRequests() {
     final OkHttpClient client = buildClient("http.client.async.maxRequests: 72");
-    assertEquals(72, client.getDispatcher().getMaxRequests());
+    assertEquals(72, client.dispatcher().getMaxRequests());
   }
 
   @Test
   public void testMaxRequestsPerHost() {
     final OkHttpClient client = buildClient("http.client.async.maxRequestsPerHost: 79");
-    assertEquals(79, client.getDispatcher().getMaxRequestsPerHost());
+    assertEquals(79, client.dispatcher().getMaxRequestsPerHost());
   }
 
   @Test
   public void testFollowRedirects() {
     final OkHttpClient client = buildClient("http.client.followRedirects: false");
-    assertEquals(false, client.getFollowRedirects());
+    assertEquals(false, client.followRedirects());
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,10 @@
                                 <ignoreDestinationPackage>
                                     <package>com.jcraft.jzlib</package>
                                 </ignoreDestinationPackage>
+                                <!-- okhttp3 references this for Android platform -->
+                                <ignoreDestinationPackage>
+                                    <package>android.util</package>
+                                </ignoreDestinationPackage>
                             </ignoreDestinationPackages>
                             <ignoreSourcePackages>
                                 <ignoreSourcePackage>


### PR DESCRIPTION
also upgrade okio

okhttp 2.x is obsolete, and according to https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-300-rc1
there should be no risk to upgrade.