### PR TITLE
do not duplicate authorization header

### DIFF
--- a/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClient.java
+++ b/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClient.java
@@ -78,7 +78,11 @@ class HttpClient implements IncomingRequestAwareClient {
 
     apolloIncomingRequest
         .flatMap(req -> req.header(AUTHORIZATION_HEADER))
-        .ifPresent(header -> headersBuilder.set(AUTHORIZATION_HEADER, header));
+        .ifPresent(header -> {
+          if (headersBuilder.get(AUTHORIZATION_HEADER) == null) {
+            headersBuilder.add(AUTHORIZATION_HEADER, header);
+          }
+        });
 
     final Request request = new Request.Builder()
         .method(apolloRequest.method(), requestBody.orElse(null))

--- a/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClient.java
+++ b/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClient.java
@@ -73,12 +73,12 @@ class HttpClient implements IncomingRequestAwareClient {
       return RequestBody.create(contentType, payload);
     });
 
-    Headers.Builder headersBuilder = new Headers.Builder();
-    apolloRequest.headers().asMap().forEach((k, v) -> headersBuilder.add(k, v));
+    final Headers.Builder headersBuilder = new Headers.Builder();
+    apolloRequest.headers().asMap().forEach(headersBuilder::add);
 
     apolloIncomingRequest
         .flatMap(req -> req.header(AUTHORIZATION_HEADER))
-        .ifPresent(header -> headersBuilder.add(AUTHORIZATION_HEADER, header));
+        .ifPresent(header -> headersBuilder.set(AUTHORIZATION_HEADER, header));
 
     final Request request = new Request.Builder()
         .method(apolloRequest.method(), requestBody.orElse(null))

--- a/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/HttpClientTest.java
+++ b/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/HttpClientTest.java
@@ -216,11 +216,11 @@ public class HttpClientTest {
 
     String uri = format("http://localhost:%d/foo.php", mockServerRule.getHttpPort());
     Request request = Request.forUri(uri, "GET")
-        .withHeader("Authorization", "Basic foobar");
+        .withHeader("Authorization", "Basic dXNlcjpwYXNz");
 
     Request originalRequest = Request
         .forUri("http://original.uri/")
-        .withHeader("Authorization", "Basic dXNlcjpwYXNz");
+        .withHeader("Authorization", "Basic foobar");
 
     final Response<ByteString> response = HttpClient.createUnconfigured()
         .send(request, Optional.of(originalRequest))

--- a/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/HttpClientTest.java
+++ b/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/HttpClientTest.java
@@ -207,6 +207,29 @@ public class HttpClientTest {
   }
 
   @Test
+  public void testNoDuplicatedAuthContext() throws Exception {
+    mockServerClient.when(
+        request().withHeader("Authorization", "Basic dXNlcjpwYXNz")
+    ).respond(
+        response().withHeader("x-auth-was-fine", "yes")
+    );
+
+    String uri = format("http://localhost:%d/foo.php", mockServerRule.getHttpPort());
+    Request request = Request.forUri(uri, "GET")
+        .withHeader("Authorization", "Basic foobar");
+
+    Request originalRequest = Request
+        .forUri("http://original.uri/")
+        .withHeader("Authorization", "Basic dXNlcjpwYXNz");
+
+    final Response<ByteString> response = HttpClient.createUnconfigured()
+        .send(request, Optional.of(originalRequest))
+        .toCompletableFuture().get();
+
+    assertThat(response.headers().get("x-auth-was-fine"), equalTo(Optional.of("yes")));
+  }
+
+  @Test
   public void testSendWeirdStatus() throws Exception {
     mockServerClient.when(
         request()


### PR DESCRIPTION
instead of adding the header without check, reset it in favor of that
from incoming request.

Does this make sense? Do we have use case replying on multiple `Authorization` header?