### PR TITLE
upgrade to okhttp3

### DIFF
--- a/apollo-bom/pom.xml
+++ b/apollo-bom/pom.xml
@@ -92,14 +92,14 @@
             </dependency>
 
             <dependency>
-                <groupId>com.squareup.okhttp</groupId>
+                <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp</artifactId>
-                <version>2.5.0</version>
+                <version>3.9.0</version>
             </dependency>
             <dependency>
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio</artifactId>
-                <version>1.6.0</version>
+                <version>1.13.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>

--- a/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/HttpServiceTest.java
+++ b/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/HttpServiceTest.java
@@ -27,8 +27,6 @@ import com.spotify.apollo.core.Service;
 import com.spotify.apollo.http.server.HttpRequestMetadata;
 import com.spotify.apollo.route.AsyncHandler;
 import com.spotify.apollo.route.Route;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -44,6 +42,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
 import okio.ByteString;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/modules/jetty-http-server/pom.xml
+++ b/modules/jetty-http-server/pom.xml
@@ -61,7 +61,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp</groupId>
+            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <scope>test</scope>
         </dependency>

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerModuleTest.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerModuleTest.java
@@ -26,8 +26,6 @@ import com.spotify.apollo.core.Service;
 import com.spotify.apollo.core.Services;
 import com.spotify.apollo.request.OngoingRequest;
 import com.spotify.apollo.request.RequestHandler;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
@@ -40,6 +38,9 @@ import java.net.ConnectException;
 import java.net.Socket;
 import java.util.List;
 import java.util.Optional;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
 
 import static com.spotify.apollo.Status.IM_A_TEAPOT;
 import static java.util.Arrays.asList;
@@ -75,7 +76,7 @@ public class HttpServerModuleTest {
           .url(baseUrl(port) + "/hello/world")
           .build();
 
-      com.squareup.okhttp.Response response = okHttpClient.newCall(request).execute();
+      okhttp3.Response response = okHttpClient.newCall(request).execute();
       assertThat(response.code(), is(IM_A_TEAPOT.code()));
 
       assertThat(testHandler.requests.size(), is(1));
@@ -100,7 +101,7 @@ public class HttpServerModuleTest {
           .url(baseUrl(port) + "/query?a=foo&b=bar&b=baz")
           .build();
 
-      com.squareup.okhttp.Response response = okHttpClient.newCall(httpRequest).execute();
+      okhttp3.Response response = okHttpClient.newCall(httpRequest).execute();
       assertThat(response.code(), is(IM_A_TEAPOT.code()));
 
       assertThat(testHandler.requests.size(), is(1));
@@ -129,7 +130,7 @@ public class HttpServerModuleTest {
           .addHeader("Repeat", "twice")
           .build();
 
-      com.squareup.okhttp.Response response = okHttpClient.newCall(httpRequest).execute();
+      okhttp3.Response response = okHttpClient.newCall(httpRequest).execute();
       assertThat(response.code(), is(IM_A_TEAPOT.code()));
 
       assertThat(testHandler.requests.size(), is(1));

--- a/modules/okhttp-client/pom.xml
+++ b/modules/okhttp-client/pom.xml
@@ -43,7 +43,7 @@
             <artifactId>apollo-environment</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp</groupId>
+            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
         <dependency>

--- a/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClientModule.java
+++ b/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClientModule.java
@@ -24,7 +24,7 @@ import com.spotify.apollo.module.AbstractApolloModule;
 import com.spotify.apollo.module.ApolloModule;
 
 import com.google.inject.multibindings.Multibinder;
-import com.squareup.okhttp.OkHttpClient;
+import okhttp3.OkHttpClient;
 
 public class HttpClientModule extends AbstractApolloModule {
 

--- a/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/TransformingCallback.java
+++ b/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/TransformingCallback.java
@@ -24,8 +24,6 @@ import com.google.common.base.Joiner;
 import com.spotify.apollo.Response;
 import com.spotify.apollo.Status;
 import com.spotify.apollo.StatusType;
-import com.squareup.okhttp.Callback;
-import com.squareup.okhttp.Request;
 
 import java.io.IOException;
 import java.text.MessageFormat;
@@ -34,6 +32,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import okhttp3.Call;
+import okhttp3.Callback;
 import okio.ByteString;
 
 class TransformingCallback implements Callback {
@@ -52,18 +52,18 @@ class TransformingCallback implements Callback {
   }
 
   @Override
-  public void onFailure(Request request, IOException e) {
-    final String message = MessageFormat.format("Request {0} failed", request);
+  public void onFailure(Call call, IOException e) {
+    final String message = MessageFormat.format("Request {0} failed", call.request());
     final IOException exception = new IOException(message, e);
     future.completeExceptionally(exception);
   }
 
   @Override
-  public void onResponse(com.squareup.okhttp.Response response) throws IOException {
+  public void onResponse(Call call, okhttp3.Response response) throws IOException {
     future.complete(transformResponse(response));
   }
 
-  static Response<ByteString> transformResponse(com.squareup.okhttp.Response response)
+  static Response<ByteString> transformResponse(okhttp3.Response response)
       throws IOException {
 
     final StatusType status =

--- a/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/HttpClientModuleTest.java
+++ b/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/HttpClientModuleTest.java
@@ -19,19 +19,20 @@
  */
 package com.spotify.apollo.http.client;
 
+import com.google.inject.Injector;
+import com.google.inject.Key;
+
 import com.spotify.apollo.core.Service;
 import com.spotify.apollo.core.Services;
 import com.spotify.apollo.environment.ClientDecorator;
-
-import com.google.inject.Injector;
-import com.google.inject.Key;
-import com.squareup.okhttp.OkHttpClient;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import org.junit.Test;
 
 import java.util.Set;
+
+import okhttp3.OkHttpClient;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -72,7 +73,7 @@ public class HttpClientModuleTest {
     try (Service.Instance i = service.start(new String[] {}, config)) {
 
       final OkHttpClient underlying = i.resolve(OkHttpClient.class);
-      assertThat(underlying.getConnectTimeout(), is(7982));
+      assertThat(underlying.connectTimeoutMillis(), is(7982));
     }
 
   }

--- a/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/HttpClientTest.java
+++ b/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/HttpClientTest.java
@@ -138,8 +138,8 @@ public class HttpClientTest {
 
     assertThat(response.status(), withCode(200));
     assertThat(response.headerEntries(), allOf(
-                   hasItem(new SimpleEntry<>("Content-Type", "application/x-spotify-location")),
-                   hasItem(new SimpleEntry<>("Vary", "Content-Type, Accept"))
+                   hasItem(new SimpleEntry<>("content-type", "application/x-spotify-location")),
+                   hasItem(new SimpleEntry<>("vary", "Content-Type, Accept"))
                ));
     assertThat(response.payload(), is(Optional.of(ByteString.encodeUtf8("world"))));
   }

--- a/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/OkHttpClientProviderTest.java
+++ b/modules/okhttp-client/src/test/java/com/spotify/apollo/http/client/OkHttpClientProviderTest.java
@@ -21,11 +21,12 @@ package com.spotify.apollo.http.client;
 
 import com.google.common.io.Closer;
 
-import com.squareup.okhttp.OkHttpClient;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import org.junit.Test;
+
+import okhttp3.OkHttpClient;
 
 import static org.junit.Assert.assertEquals;
 
@@ -40,34 +41,34 @@ public class OkHttpClientProviderTest {
 
   @Test
   public void testConnectTimeout() {
-    assertEquals(1234, buildClient("http.client.connectTimeout: 1234").getConnectTimeout());
+    assertEquals(1234, buildClient("http.client.connectTimeout: 1234").connectTimeoutMillis());
   }
 
   @Test
   public void testReadTimeout() {
-    assertEquals(444, buildClient("http.client.readTimeout: 444").getReadTimeout());
+    assertEquals(444, buildClient("http.client.readTimeout: 444").readTimeoutMillis());
   }
 
   @Test
   public void testWriteTimeout() {
-    assertEquals(5555, buildClient("http.client.writeTimeout: 5555").getWriteTimeout());
+    assertEquals(5555, buildClient("http.client.writeTimeout: 5555").writeTimeoutMillis());
   }
 
   @Test
   public void testMaxRequests() {
     final OkHttpClient client = buildClient("http.client.async.maxRequests: 72");
-    assertEquals(72, client.getDispatcher().getMaxRequests());
+    assertEquals(72, client.dispatcher().getMaxRequests());
   }
 
   @Test
   public void testMaxRequestsPerHost() {
     final OkHttpClient client = buildClient("http.client.async.maxRequestsPerHost: 79");
-    assertEquals(79, client.getDispatcher().getMaxRequestsPerHost());
+    assertEquals(79, client.dispatcher().getMaxRequestsPerHost());
   }
 
   @Test
   public void testFollowRedirects() {
     final OkHttpClient client = buildClient("http.client.followRedirects: false");
-    assertEquals(false, client.getFollowRedirects());
+    assertEquals(false, client.followRedirects());
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,10 @@
                                 <ignoreDestinationPackage>
                                     <package>com.jcraft.jzlib</package>
                                 </ignoreDestinationPackage>
+                                <!-- okhttp3 references this for Android platform -->
+                                <ignoreDestinationPackage>
+                                    <package>android.util</package>
+                                </ignoreDestinationPackage>
                             </ignoreDestinationPackages>
                             <ignoreSourcePackages>
                                 <ignoreSourcePackage>


### PR DESCRIPTION
also upgrade okio

okhttp 2.x is obsolete, and according to https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-300-rc1
there should be no risk to upgrade.
  
backport of #220 