### PR TITLE
Updated WithReasonPhrase.create to handle nulls

### DIFF
--- a/apollo-api/src/main/java/com/spotify/apollo/Status.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/Status.java
@@ -148,7 +148,12 @@ public enum Status implements StatusType {
     public abstract Family family();
 
     public static WithReasonPhrase create(int statusCode, String reasonPhrase) {
-      String safeReasonPhrase = ILLEGAL_REASONPHRASE_CHARS.replaceFrom(reasonPhrase, ' ');
+      String safeReasonPhrase;
+      if (reasonPhrase == null) {
+        safeReasonPhrase = "";
+      } else {
+        safeReasonPhrase = ILLEGAL_REASONPHRASE_CHARS.replaceFrom(reasonPhrase, ' ');
+      }
       return new AutoValue_Status_WithReasonPhrase(statusCode, safeReasonPhrase, Family.familyOf(statusCode));
     }
 


### PR DESCRIPTION
If the reasonPhrase being passed into this method is null, the `.replaceFrom` method will throw an NPE.
This can occur easily when doing the following:

```
Status.INTERNAL_SERVER_ERROR
          .withReasonPhrase(ex.getMessage()); // Where the message is nullable
```

This may not be the correct approach. But I have noticed this in our services, and I am open to suggestions.