### PR TITLE
Add file-descriptor-ratio metric

### DIFF
--- a/modules/metrics/pom.xml
+++ b/modules/metrics/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <semantic-metrics.version>0.6.0</semantic-metrics.version>
+        <semantic-metrics.version>0.9.0</semantic-metrics.version>
     </properties>
 
     <dependencyManagement>

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsModule.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsModule.java
@@ -34,6 +34,7 @@ import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
 import com.spotify.metrics.ffwd.FastForwardReporter;
 import com.spotify.metrics.jvm.CpuGaugeSet;
+import com.spotify.metrics.jvm.FileDescriptorGaugeSet;
 import com.spotify.metrics.jvm.GarbageCollectorMetricSet;
 import com.spotify.metrics.jvm.MemoryUsageGaugeSet;
 import com.spotify.metrics.jvm.ThreadStatesMetricSet;
@@ -42,7 +43,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Named;
@@ -91,6 +91,7 @@ public class MetricsModule extends AbstractApolloModule {
     metricRegistry.register(MetricId.EMPTY, new GarbageCollectorMetricSet());
     metricRegistry.register(MetricId.EMPTY, new ThreadStatesMetricSet());
     metricRegistry.register(MetricId.EMPTY, CpuGaugeSet.create());
+    metricRegistry.register(MetricId.EMPTY, new FileDescriptorGaugeSet());
 
     return metricRegistry;
   }

--- a/modules/metrics/src/test/java/com/spotify/apollo/metrics/MetricsTest.java
+++ b/modules/metrics/src/test/java/com/spotify/apollo/metrics/MetricsTest.java
@@ -24,7 +24,6 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.name.Names;
 
-import com.codahale.metrics.Metric;
 import com.spotify.apollo.core.Services;
 import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricFilter;
@@ -64,6 +63,9 @@ public class MetricsTest extends AbstractModule {
 
     assertFalse("Expected CpuGaugeSet metrics to be registered with registry",
                 metricRegistry.getGauges(filterByTag("what", "process-cpu-load-percentage")).isEmpty());
+
+    assertFalse("Expected FileDescriptorRatioGaugeSet metrics to be registered with registry",
+                metricRegistry.getGauges(filterByTag("what", "file-descriptor-ratio")).isEmpty());
   }
 
   private SemanticMetricFilter filterByTag(final String tagName, final String tagValue){


### PR DESCRIPTION
Bump semantic-metrics to access `FileDescriptorGaugeSet`

Ported from master branch. Original PR #214 

@gimaker 