### PR TITLE
Introduce ffwd reporter over HTTP

### DIFF
--- a/modules/metrics/README.md
+++ b/modules/metrics/README.md
@@ -121,9 +121,7 @@ key | type | required | note
 --- | ---- | -------- | ----
 `metrics.server` | string list | optional | list of [`What`](src/main/java/com/spotify/apollo/metrics/semantic/What.java) names to enable; defaults to [ENDPOINT_REQUEST_RATE, ENDPOINT_REQUEST_DURATION, DROPPED_REQUEST_RATE, ERROR_RATIO]
 `metrics.precreate-codes` | int list | optional | list of status codes to precreate request-rate meters for, default empty
-`ffwd.interval` | int | optional | interval in seconds of reporting metrics to ffwd; default 30
-`ffwd.host` | string | optional | host where ffwd is running; default localhost
-`ffwd.port` | int | optional | port where ffwd is running; default 19091
+`ffwd.type` | string | optional | indicates which type of ffwd reporter to use. Available types are `agent` and `http`. see below for details. default is `agent`.
 
 You may not want to enable all the metrics Apollo can create, since some of them can be expensive 
 (in particular on the alerting and graphing side), hence the ability to configure which
@@ -135,6 +133,75 @@ seen. This can lead to strange effects when, for instance, an error shows up
 for the first time after a restart. Pre-creating meters for status codes you 
 want to alert on makes it less likely to get false positives, since Apollo
 will then emit a '0' value until the first time a certain status code shows up.
+
+### ffwd.type = `agent`
+
+key | type | required | note
+--- | ---- | -------- | ----
+`ffwd.interval` | int | optional | interval in seconds of reporting metrics to ffwd; default 30
+`ffwd.host` | string | optional | host where the ffwd agent is running. default `localhost`
+`ffwd.port` | int | optional | port where the ffwd agent is running. default `19091`
+
+#### Example
+
+```
+ffwd.type = agent
+ffwd.interval = 30
+ffwd.host = "localhost"
+ffwd.port = 19091
+```
+
+### ffwd.type = `http`
+
+key | type | required | note
+--- | ---- | -------- | ----
+`ffwd.interval` | int | optional | interval in seconds of reporting metrics to ffwd; default 30
+`ffwd.discovery.type` | string | required | indicates how to discovery http endpoints. Available options are `static` and `srv`. See below for details.
+
+#### Example
+
+```
+ffwd.type = http
+ffwd.interval = 30
+ffwd.discovery = {
+  type = "srv"
+  record = "_metrics-api._http.example.com."
+}
+```
+
+### ffwd.discovery.type = `static`
+
+Provides a "hardcoded" endpoint to send metrics to. This is primarily useful during testing since it doesn't provide any fallback mechanisms in case a remote endpoint goes down.
+
+key | type | required | note
+--- | ---- | -------- | ----
+`ffwd.discovery.host` | string | required | host to send metric batches to.
+`ffwd.discovery.port` | int | required | port to send metric batches to.
+
+#### Example
+
+```
+ffwd.discovery = {
+  type = static
+  host = "localhost"
+  port = "8080"
+}
+```
+
+### ffwd.discovery.type = `srv`
+
+key | type | required | note
+--- | ---- | -------- | ----
+`ffwd.discovery.record` | string | required | SRV record to use when looking up http endpoints. if this _does not_ end with a dot (`.`), it will use `apollo.domain` as a search domain.
+
+#### Example
+
+```
+ffwd.discovery = {
+  type = srv
+  record = "_metrics-api._http.example.com."
+}
+```
 
 ## Custom Metrics
 

--- a/modules/metrics/pom.xml
+++ b/modules/metrics/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <semantic-metrics.version>0.9.0</semantic-metrics.version>
+        <semantic-metrics.version>0.11.2</semantic-metrics.version>
     </properties>
 
     <dependencyManagement>
@@ -46,6 +46,11 @@
         <dependency>
             <groupId>com.spotify.metrics</groupId>
             <artifactId>semantic-metrics-ffwd-reporter</artifactId>
+            <version>${semantic-metrics.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.spotify.metrics</groupId>
+            <artifactId>semantic-metrics-ffwd-http-reporter</artifactId>
             <version>${semantic-metrics.version}</version>
         </dependency>
 

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/DiscoveryConfig.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/DiscoveryConfig.java
@@ -1,0 +1,88 @@
+/*
+ * -\-\-
+ * Spotify Apollo Metrics
+ * --
+ * Copyright (C) 2013 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.metrics;
+
+import com.spotify.ffwd.http.HttpDiscovery;
+import com.typesafe.config.Config;
+import java.util.Collections;
+
+public interface DiscoveryConfig {
+  /**
+   * Build an HTTP discovery component.
+   */
+  HttpDiscovery toHttpDiscovery();
+
+  static DiscoveryConfig fromConfig(final Config config) {
+    final String type = config.getString("type");
+
+    switch (type) {
+      case "static":
+        final String host = config.getString("host");
+        final int port = config.getInt("port");
+        return new Static(host, port);
+      case "srv":
+        final String record = config.getString("record");
+        return new Srv(record);
+      default:
+        throw new RuntimeException("Unrecognized discovery type: " + type);
+    }
+  }
+
+  class Static implements DiscoveryConfig {
+    private final String host;
+    private final int port;
+
+    Static(final String host, final int port) {
+      this.host = host;
+      this.port = port;
+    }
+
+    String getHost() {
+      return host;
+    }
+
+    int getPort() {
+      return port;
+    }
+
+    @Override
+    public HttpDiscovery toHttpDiscovery() {
+      final HttpDiscovery.HostAndPort server = new HttpDiscovery.HostAndPort(host, port);
+      return new HttpDiscovery.Static(Collections.singletonList(server));
+    }
+  }
+
+  class Srv implements DiscoveryConfig {
+    private final String record;
+
+    Srv(final String record) {
+      this.record = record;
+    }
+
+    String getRecord() {
+      return record;
+    }
+
+    @Override
+    public HttpDiscovery toHttpDiscovery() {
+      return new HttpDiscovery.Srv(record);
+    }
+  }
+}

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/FastForwardLifecycle.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/FastForwardLifecycle.java
@@ -1,0 +1,26 @@
+/*
+ * -\-\-
+ * Spotify Apollo Metrics
+ * --
+ * Copyright (C) 2013 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.metrics;
+
+import java.io.Closeable;
+
+@FunctionalInterface
+public interface FastForwardLifecycle extends Closeable {
+}

--- a/modules/metrics/src/test/java/com/spotify/apollo/metrics/ConfigTest.java
+++ b/modules/metrics/src/test/java/com/spotify/apollo/metrics/ConfigTest.java
@@ -19,37 +19,93 @@
  */
 package com.spotify.apollo.metrics;
 
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
+import static org.junit.Assert.assertEquals;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertEquals;
-
 @RunWith(Enclosed.class)
 public class ConfigTest {
-
   public static class FfwdSettings {
     @Test
     public void ffwdScheduleDefaultsToEvery39Seconds() {
       String json = "{}";
-      FfwdConfig ffwdCompletelyEmpty = new FfwdConfig(conf(json));
+
+      FfwdConfig.Agent ffwdCompletelyEmpty = (FfwdConfig.Agent) FfwdConfig.fromConfig(conf(json));
 
       String ffwdjson = "{\"ffwd\":{}}";
-      FfwdConfig ffwdEmpty = new FfwdConfig(conf(ffwdjson));
+      FfwdConfig.Agent ffwdEmpty = (FfwdConfig.Agent) FfwdConfig.fromConfig(conf(ffwdjson));
 
+      assertEquals(Optional.empty(), ffwdCompletelyEmpty.getHost());
+      assertEquals(Optional.empty(), ffwdCompletelyEmpty.getPort());
       assertEquals(30, ffwdCompletelyEmpty.getInterval());
       assertEquals(30, ffwdEmpty.getInterval());
     }
 
     @Test
+    public void httpConfig() {
+      String json =
+          "{\"ffwd\":{\"type\":\"http\",\"discovery\":{\"type\":\"srv\",\"record\":\"hello\"}}}";
+      FfwdConfig config = FfwdConfig.fromConfig(conf(json));
+
+      assertEquals(FfwdConfig.Http.class, config.getClass());
+
+      final FfwdConfig.Http http = (FfwdConfig.Http) config;
+
+      assertEquals(30, http.getInterval());
+    }
+
+    @Test
     public void ffwdScheduleCanBeSetFromConfig() {
       String json = "{\"ffwd\":{ \"interval\": 15}}";
-      FfwdConfig ffwd = new FfwdConfig(conf(json));
+      FfwdConfig.Agent ffwd = (FfwdConfig.Agent) FfwdConfig.fromConfig(conf(json));
 
       assertEquals(15, ffwd.getInterval());
+    }
+  }
+
+  public static class DiscoveryConfigTest {
+    @Test
+    public void testSrv() {
+      final DiscoveryConfig discovery =
+          DiscoveryConfig.fromConfig(conf("{\"type\":\"srv\",\"record\":\"foo\"}"));
+
+      assertEquals(DiscoveryConfig.Srv.class, discovery.getClass());
+      final DiscoveryConfig.Srv srv = (DiscoveryConfig.Srv) discovery;
+
+      assertEquals("foo", srv.getRecord());
+    }
+
+    @Test(expected = ConfigException.Missing.class)
+    public void testSrvMissingRecord() {
+      DiscoveryConfig.fromConfig(conf("{\"type\":\"srv\"}"));
+    }
+
+    @Test
+    public void testStatic() {
+      final DiscoveryConfig discovery =
+          DiscoveryConfig.fromConfig(conf("{\"type\":\"static\",\"host\":\"foo\",\"port\":12345}"));
+
+      assertEquals(DiscoveryConfig.Static.class, discovery.getClass());
+      final DiscoveryConfig.Static st = (DiscoveryConfig.Static) discovery;
+
+      assertEquals("foo", st.getHost());
+      assertEquals(12345, st.getPort());
+    }
+
+    @Test(expected = ConfigException.Missing.class)
+    public void testStaticMissingHost() {
+      DiscoveryConfig.fromConfig(conf("{\"type\":\"static\",\"port\":12345}"));
+    }
+
+    @Test(expected = ConfigException.Missing.class)
+    public void testStaticMissingPort() {
+      DiscoveryConfig.fromConfig(conf("{\"type\":\"static\",\"host\":\"foo\"}"));
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,9 @@
                                 <ignoreSourcePackage>
                                     <package>io.netty.util.internal</package>
                                 </ignoreSourcePackage>
+                                <ignoreSourcePackage>
+                                    <package>com.spotify.ffwd.http.okhttp3.internal.platform</package>
+                                </ignoreSourcePackage>
                             </ignoreSourcePackages>
                         </configuration>
                         <executions>


### PR DESCRIPTION
This reporter can be enabled with the following configuration:

```
ffwd.type = http
ffwd.discovery = {
    type = "static"
    host = "localhost"
    port = 12345
}
```

Or the following for `srv`:

```
ffwd.type = http
ffwd.discovery = {
    type = "srv"
    record = "_ffwd._http"
}
```

For srv discovery, `apollo.domain` would be used as a search domain if
present.