### PR TITLE
Add ability to track number of requests hitting a duration goal by

### DIFF
--- a/modules/metrics/README.md
+++ b/modules/metrics/README.md
@@ -118,7 +118,8 @@ A Meter, tagged with:
 | what        | "endpoint-request-duration-threshold-rate"     | Enable/disable with endpoint-duration-goal config           |
 | threshold   | *                 | The request duration goal, in milliseconds                   |
 
-If a duration goal is set in configuration (`endpoint-duration-goal`), this meter will be marked when a request meets its goal.
+This meter will only be created if a duration goal is set in the configuration (`endpoint-duration-goal`). The meter will be marked when a request meets its goal.
+
 
 ## [ffwd](https://github.com/spotify/ffwd) reporter
 
@@ -220,12 +221,15 @@ key | type | required | note
 --- | ---- | -------- | ----
 `endpoint-duration-goal.{endpoint}.{method}` | int | required | Duration threshold in milliseconds for an endpoint/method combination
 
+**Note** If an endpoint has a parameter it needs to be included. For example a route defined as `GET:/example/<name>` would have
+be configured as `/v1/example-b/<name>.GET`
+
 #### Example
 
 ```
 endpoint-duration-goal = {
-  /v1/test-a.GET = 200 # meter marked every time this endpoint resolves in under 200 ms
-  /v1/test-b.GET = 100 # meter marked every time this endpoint resolves in under 100 ms
+  /v1/example-a.GET        = 200 # meter marked every time this endpoint resolves in under 200 ms
+  /v1/example-b/<name>.GET = 100 # meter marked every time this endpoint with a named parameter resolves in under 100 ms
 }
 ```
 

--- a/modules/metrics/README.md
+++ b/modules/metrics/README.md
@@ -98,7 +98,7 @@ the last 5 minutes, etc. The metrics do not include dropped requests.
 
 ### Dropped Requests
 
-A Meter, tagged with: 
+A Meter, tagged with:
 
 | tag         | value                      | comment                                              |
 |-------------|----------------------------|------------------------------------------------------|
@@ -106,9 +106,19 @@ A Meter, tagged with:
 | unit        | "request"                  |                                                      |
 
 Requests are dropped when they expire: if they have a time-to-live and are older than
-that TTL, Apollo will not try to respond. Apollo may also drop requests if it is 
+that TTL, Apollo will not try to respond. Apollo may also drop requests if it is
 overloaded and cannot respond to all incoming requests.
 
+### Endpoint Duration Goal
+
+A Meter, tagged with:
+
+| tag         | value                      | comment                                              |
+|-------------|----------------------------|------------------------------------------------------|
+| what        | "endpoint-request-duration-threshold-rate"     | Enable/disable with endpoint-duration-goal config           |
+| threshold   | *                 | The request duration goal, in milliseconds                   |
+
+If a duration goal is set in configuration (`endpoint-duration-goal`), this meter will be marked when a request meets its goal.
 
 ## [ffwd](https://github.com/spotify/ffwd) reporter
 
@@ -122,15 +132,16 @@ key | type | required | note
 `metrics.server` | string list | optional | list of [`What`](src/main/java/com/spotify/apollo/metrics/semantic/What.java) names to enable; defaults to [ENDPOINT_REQUEST_RATE, ENDPOINT_REQUEST_DURATION, DROPPED_REQUEST_RATE, ERROR_RATIO]
 `metrics.precreate-codes` | int list | optional | list of status codes to precreate request-rate meters for, default empty
 `ffwd.type` | string | optional | indicates which type of ffwd reporter to use. Available types are `agent` and `http`. see below for details. default is `agent`.
+`endpoint-duration-goal`  | int map  | optional |  sets request duration thresholds in milliseconds to track how many requests meet a duration objective
 
-You may not want to enable all the metrics Apollo can create, since some of them can be expensive 
+You may not want to enable all the metrics Apollo can create, since some of them can be expensive
 (in particular on the alerting and graphing side), hence the ability to configure which
 metrics to emit via `metrics.server`.
 
 The `metrics.precreate-codes` setting is there since the request-rate meters
 are lazily created. Apollo doesn't emit any metrics for status codes it hasn't
 seen. This can lead to strange effects when, for instance, an error shows up
-for the first time after a restart. Pre-creating meters for status codes you 
+for the first time after a restart. Pre-creating meters for status codes you
 want to alert on makes it less likely to get false positives, since Apollo
 will then emit a '0' value until the first time a certain status code shows up.
 
@@ -203,6 +214,33 @@ ffwd.discovery = {
 }
 ```
 
+### endpoint-duration-goal
+
+key | type | required | note
+--- | ---- | -------- | ----
+`endpoint-duration-goal.{endpoint}.{method}` | int | required | Duration threshold in milliseconds for an endpoint/method combination
+
+#### Example
+
+```
+endpoint-duration-goal = {
+  /v1/test-a.GET = 200 # meter marked every time this endpoint resolves in under 200 ms
+  /v1/test-b.GET = 100 # meter marked every time this endpoint resolves in under 100 ms
+}
+```
+
+key | type | required | note
+--- | ---- | -------- | ----
+`endpoint-duration-goal.all-endpoints` | int | required | Global duration threshold in milliseconds, will be overridden by endpoint specific goals
+
+#### Example
+
+```
+endpoint-duration-goal = {
+  all-endpoints = 500 # unless individually overridden, a goal of 500ms for all endpoints
+}
+```
+
 ## Custom Metrics
 
 To set up custom metrics on the application level you'll need to get hold of the
@@ -229,4 +267,3 @@ for some description of how to do request handling decorations.
 For client-side metrics, wrap the ```Client``` you get from the ```RequestContext``` in a similar
 way to how ```DecoratingClient``` is implemented. In your wrapper, ensure that the right metrics
 are tracked.
-

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsModule.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsModule.java
@@ -127,12 +127,12 @@ public class MetricsModule extends AbstractApolloModule {
   @Provides
   @Singleton
   public MetricsFactory apolloMetrics(
-      SemanticMetricRegistry metricRegistry, MetricsConfig metricsConfig
-  ) {
+      SemanticMetricRegistry metricRegistry, MetricsConfig metricsConfig) {
     return new SemanticMetricsFactory(
         metricRegistry,
         what -> metricsConfig.serverMetrics().contains(what),
-        metricsConfig.precreateCodes()
+        metricsConfig.precreateCodes(),
+        metricsConfig.durationThresholdConfig()
     );
   }
 

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/DurationThresholdConfig.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/DurationThresholdConfig.java
@@ -57,14 +57,10 @@ public class DurationThresholdConfig {
   }
 
   private static Optional<Integer> parseAllEndpoints(final Config config) {
-    final Optional<Integer> allEndpoints;
-    final Config durationGoalConfig = config.getObject("endpoint-duration-goal").toConfig();
-    if (durationGoalConfig.hasPath("all-endpoints")) {
-      allEndpoints = Optional.of(durationGoalConfig.getInt("all-endpoints"));
-    } else {
-      allEndpoints = Optional.empty();
+    if (config.hasPath("endpoint-duration-goal.all-endpoints")) {
+      return Optional.of(config.getInt("endpoint-duration-goal.all-endpoints"));
     }
-    return allEndpoints;
+    return Optional.empty();
   }
 
   public static DurationThresholdConfig parseConfig(final Config config) {

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/DurationThresholdConfig.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/DurationThresholdConfig.java
@@ -1,0 +1,88 @@
+/*
+ * -\-\-
+ * Spotify Apollo Metrics Module
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.metrics.semantic;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValue;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DurationThresholdConfig {
+
+  private final Optional<Integer> allEndpoints;
+  private final Map<String, Optional<Integer>> goals;
+
+  private DurationThresholdConfig(final Optional<Integer> allEndpoints,
+                                  final Map<String, Optional<Integer>> goals) {
+    this.allEndpoints = allEndpoints;
+    this.goals = goals;
+  }
+
+  public Optional<Integer> getDurationThresholdForEndpoint(final String endpointMethod) {
+    return goals.getOrDefault(endpointMethod, allEndpoints);
+  }
+
+  private static Set<Map.Entry<String, Optional<Integer>>> flattenNestedConfig(
+      Map.Entry<String, ConfigValue> entry) {
+    return ((Map<String, Integer>) entry.getValue().unwrapped())
+        .entrySet()
+        .stream()
+        .collect(
+            Collectors.toMap(
+                methodEntry -> String.format("%s:%s", methodEntry.getKey(), entry.getKey()),
+                methodEntry -> Optional.of(methodEntry.getValue())
+            )
+        ).entrySet();
+  }
+
+  private static Optional<Integer> parseAllEndpoints(final Config config) {
+    final Optional<Integer> allEndpoints;
+    final Config durationGoalConfig = config.getObject("endpoint-duration-goal").toConfig();
+    if (durationGoalConfig.hasPath("all-endpoints")) {
+      allEndpoints = Optional.of(durationGoalConfig.getInt("all-endpoints"));
+    } else {
+      allEndpoints = Optional.empty();
+    }
+    return allEndpoints;
+  }
+
+  public static DurationThresholdConfig parseConfig(final Config config) {
+    if (config.hasPath("endpoint-duration-goal")) {
+      final Map<String, Optional<Integer>> goals =
+          config.getObject("endpoint-duration-goal")
+              .withoutKey("all-endpoints")
+              .entrySet()
+              .stream()
+              .map(entry -> flattenNestedConfig(entry))
+              .flatMap(Collection::stream)
+              .collect(
+                  Collectors.toMap(
+                      Map.Entry::getKey,
+                      Map.Entry::getValue));
+      return new DurationThresholdConfig(parseAllEndpoints(config), goals);
+    }
+    return new DurationThresholdConfig(Optional.empty(), ImmutableMap.of());
+  }
+}
+

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/DurationThresholdTracker.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/DurationThresholdTracker.java
@@ -1,0 +1,52 @@
+/*
+ * -\-\-
+ * Spotify Apollo Metrics Module
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.metrics.semantic;
+
+import static com.spotify.apollo.metrics.semantic.What.ENDPOINT_REQUEST_DURATION_THRESHOLD_RATE;
+
+import com.codahale.metrics.Meter;
+import com.spotify.metrics.core.MetricId;
+import com.spotify.metrics.core.SemanticMetricRegistry;
+
+public class DurationThresholdTracker {
+
+  private final Meter durationThresholdMeter;
+  private final Integer threshold;
+
+  public DurationThresholdTracker(MetricId id, SemanticMetricRegistry
+      metricRegistry, Integer threshold) {
+    final MetricId thresholdId = id.tagged("what", ENDPOINT_REQUEST_DURATION_THRESHOLD_RATE.tag())
+        .tagged("threshold", threshold.toString());
+    this.durationThresholdMeter = metricRegistry.meter(thresholdId);
+    this.threshold = threshold;
+  }
+
+  /**
+   * Compares the duration of the current request (milliseconds) to the a
+   * threshold goal and tracks how many requests meet this goal.
+   *
+   * @param duration - the duration of the current request
+   */
+  public void markDurationThresholds(final long duration) {
+    if (duration <= threshold) {
+      durationThresholdMeter.mark();
+    }
+  }
+}

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/MetricsConfig.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/MetricsConfig.java
@@ -21,6 +21,7 @@ package com.spotify.apollo.metrics.semantic;
 
 import com.typesafe.config.Config;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -31,6 +32,7 @@ import javax.inject.Inject;
 
 import static com.spotify.apollo.metrics.semantic.What.DROPPED_REQUEST_RATE;
 import static com.spotify.apollo.metrics.semantic.What.ENDPOINT_REQUEST_DURATION;
+import static com.spotify.apollo.metrics.semantic.What.ENDPOINT_REQUEST_DURATION_THRESHOLD_RATE;
 import static com.spotify.apollo.metrics.semantic.What.ENDPOINT_REQUEST_RATE;
 import static com.spotify.apollo.metrics.semantic.What.ERROR_RATIO;
 
@@ -42,11 +44,13 @@ public class MetricsConfig {
       EnumSet.of(
           ENDPOINT_REQUEST_RATE,
           ENDPOINT_REQUEST_DURATION,
+          ENDPOINT_REQUEST_DURATION_THRESHOLD_RATE,
           DROPPED_REQUEST_RATE,
           ERROR_RATIO);
 
   private final Set<What> enabledMetrics;
   private final Set<Integer> precreateCodes;
+  private final DurationThresholdConfig durationThresholdConfig;
 
   @Inject
   MetricsConfig(Config config) {
@@ -61,6 +65,7 @@ public class MetricsConfig {
     } else {
       precreateCodes = Collections.emptySet();
     }
+    durationThresholdConfig = DurationThresholdConfig.parseConfig(config);
   }
 
   private Set<What> parseConfig(List<String> metrics) {
@@ -72,6 +77,8 @@ public class MetricsConfig {
 
     return result;
   }
+
+  public DurationThresholdConfig durationThresholdConfig() { return durationThresholdConfig; }
 
   public Set<What> serverMetrics() {
     return enabledMetrics;

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/SemanticMetricsFactory.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/SemanticMetricsFactory.java
@@ -23,7 +23,6 @@ import com.spotify.apollo.metrics.MetricsFactory;
 import com.spotify.apollo.metrics.ServiceMetrics;
 import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
-
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -33,19 +32,22 @@ public class SemanticMetricsFactory implements MetricsFactory {
   private final MetricId metricId;
   private final Predicate<What> enabledMetrics;
   private final Set<Integer> precreateCodes;
+  private final DurationThresholdConfig durationThresholdConfig;
 
   public SemanticMetricsFactory(final SemanticMetricRegistry metricRegistry,
                                 Predicate<What> enabledMetrics,
-                                Set<Integer> precreateCodes) {
+                                Set<Integer> precreateCodes,
+                                DurationThresholdConfig durationThresholdConfig) {
     this.metricRegistry = metricRegistry;
     this.metricId = MetricId.build();
     this.enabledMetrics = enabledMetrics;
     this.precreateCodes = precreateCodes;
+    this.durationThresholdConfig = durationThresholdConfig;
   }
 
   @Override
   public ServiceMetrics createForService(String serviceName) {
     final MetricId id = metricId.tagged("service", serviceName);
-    return new SemanticServiceMetrics(metricRegistry, id, precreateCodes, enabledMetrics);
+    return new SemanticServiceMetrics(metricRegistry, id, precreateCodes, enabledMetrics, durationThresholdConfig);
   }
 }

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/What.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/What.java
@@ -31,7 +31,8 @@ public enum What {
   ENDPOINT_REQUEST_DURATION("endpoint-request-duration"),
   ERROR_RATIO("error-ratio"),
   ERROR_RATIO_4XX("error-ratio-4xx"),
-  ERROR_RATIO_5XX("error-ratio-5xx")
+  ERROR_RATIO_5XX("error-ratio-5xx"),
+  ENDPOINT_REQUEST_DURATION_THRESHOLD_RATE("endpoint-request-duration-threshold-rate")
   ;
 
   private final String tag;

--- a/modules/metrics/src/test/java/com/spotify/apollo/metrics/semantic/DurationThresholdTrackerTest.java
+++ b/modules/metrics/src/test/java/com/spotify/apollo/metrics/semantic/DurationThresholdTrackerTest.java
@@ -1,0 +1,54 @@
+/*
+ * -\-\-
+ * Spotify Apollo Metrics Module
+ * --
+ * Copyright (C) 2013 - 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.metrics.semantic;
+
+import static com.spotify.apollo.metrics.semantic.What.ENDPOINT_REQUEST_DURATION_THRESHOLD_RATE;
+import static org.junit.Assert.assertEquals;
+
+import com.codahale.metrics.Meter;
+import com.spotify.metrics.core.MetricId;
+import com.spotify.metrics.core.SemanticMetricRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DurationThresholdTrackerTest {
+  private DurationThresholdTracker durationThresholdTracker;
+  private SemanticMetricRegistry registry;
+  private MetricId metricId;
+
+  @Before
+  public void setUp() throws Exception {
+    registry = new SemanticMetricRegistry();
+    metricId = MetricId.build();
+    durationThresholdTracker = new DurationThresholdTracker(metricId, registry, 50);
+  }
+
+  @Test
+  public void markDurationThresholds() throws Exception {
+    final Meter meter = registry.getMeters().get(metricId.tagged("what",
+        ENDPOINT_REQUEST_DURATION_THRESHOLD_RATE.tag()).tagged("threshold", "50"));
+    durationThresholdTracker.markDurationThresholds(20);
+    durationThresholdTracker.markDurationThresholds(50);
+    durationThresholdTracker.markDurationThresholds(100); // should not affect count
+    final long count = meter.getCount();
+    assertEquals(2, count);
+  }
+
+}


### PR DESCRIPTION
This code adds the ability for Apollo users to configure latency goals for their endpoints, and tracks how many requests meet these goals in a meter.

