### PR TITLE
Extract metric tags from environment variables.

### DIFF
--- a/modules/metrics/README.md
+++ b/modules/metrics/README.md
@@ -271,3 +271,10 @@ for some description of how to do request handling decorations.
 For client-side metrics, wrap the ```Client``` you get from the ```RequestContext``` in a similar
 way to how ```DecoratingClient``` is implemented. In your wrapper, ensure that the right metrics
 are tracked.
+
+## Custom Tags
+
+Metrics can be decorated with custom tags by setting environment variables.
+
+- `FFWD_TAG_environment=production` will append `environment: production` to all metrics.
+- `FFWD_TAG_foo=bar` will tag metrics with `foo: bar`

--- a/modules/metrics/pom.xml
+++ b/modules/metrics/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <semantic-metrics.version>0.11.2</semantic-metrics.version>
+        <semantic-metrics.version>0.11.4</semantic-metrics.version>
     </properties>
 
     <dependencyManagement>

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/FfwdConfig.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/FfwdConfig.java
@@ -27,6 +27,7 @@ import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricRegistry;
 import com.spotify.metrics.ffwd.FastForwardReporter;
 import com.spotify.metrics.ffwdhttp.FastForwardHttpReporter;
+import com.spotify.metrics.tags.EnvironmentTagExtractor;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.util.Optional;
@@ -95,6 +96,7 @@ interface FfwdConfig {
       final FastForwardReporter.Builder builder = FastForwardReporter
           .forRegistry(metricRegistry)
           .schedule(TimeUnit.SECONDS, interval)
+          .tagExtractor(new EnvironmentTagExtractor())
           .prefix(metricId);
 
       host.ifPresent(builder::host);
@@ -136,6 +138,7 @@ interface FfwdConfig {
 
       final FastForwardHttpReporter.Builder builder = FastForwardHttpReporter
           .forRegistry(metricRegistry, httpClient.build())
+          .tagExtractor(new EnvironmentTagExtractor())
           .schedule(interval, TimeUnit.SECONDS)
           .prefix(metricId);
 


### PR DESCRIPTION
* Bump semantic metrics version
* Add tag extractor that extracts tags from environment variables.
`FFWD_TAG_foo=bar` will result in a kv tag of `foo=bar`.