### PR TITLE
RFC: put error messages in payload of response

### DIFF
--- a/apollo-api-impl/src/main/java/com/spotify/apollo/dispatch/EndpointInvocationHandler.java
+++ b/apollo-api-impl/src/main/java/com/spotify/apollo/dispatch/EndpointInvocationHandler.java
@@ -26,6 +26,8 @@ import com.spotify.apollo.RequestContext;
 import com.spotify.apollo.request.EndpointRunnableFactory;
 import com.spotify.apollo.request.OngoingRequest;
 
+import okio.ByteString;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,6 +92,7 @@ public class EndpointInvocationHandler implements EndpointRunnableFactory {
     LOG.warn("Got Exception {} when invoking endpoint for request: {}",
              message, ongoingRequest.request(), e);
 
-    ongoingRequest.reply(forStatus(INTERNAL_SERVER_ERROR.withReasonPhrase(message)));
+    ongoingRequest.reply(
+        forStatus(INTERNAL_SERVER_ERROR).withPayload(ByteString.encodeUtf8(message)));
   }
 }

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/dispatch/EndpointInvocationHandlerTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/dispatch/EndpointInvocationHandlerTest.java
@@ -125,7 +125,7 @@ public class EndpointInvocationHandlerTest {
 
     verify(ongoingRequest).reply(messageArgumentCaptor.capture());
 
-    assertThat(messageArgumentCaptor.getValue().status().reasonPhrase(),
+    assertThat(messageArgumentCaptor.getValue().payload().get().utf8(),
                containsString(exception.getMessage()));
   }
 
@@ -158,15 +158,15 @@ public class EndpointInvocationHandlerTest {
 
     verify(ongoingRequest).reply(messageArgumentCaptor.capture());
 
-    assertThat(messageArgumentCaptor.getValue().status().reasonPhrase(),
+    assertThat(messageArgumentCaptor.getValue().payload().get().utf8(),
                containsString("expected"));
-    assertThat(messageArgumentCaptor.getValue().status().reasonPhrase(),
+    assertThat(messageArgumentCaptor.getValue().payload().get().utf8(),
                containsString("with multiple"));
-    assertThat(messageArgumentCaptor.getValue().status().reasonPhrase(),
+    assertThat(messageArgumentCaptor.getValue().payload().get().utf8(),
                containsString("lines"));
-    assertThat(messageArgumentCaptor.getValue().status().reasonPhrase(),
+    assertThat(messageArgumentCaptor.getValue().payload().get().utf8(),
                not(containsString("\r")));
-    assertThat(messageArgumentCaptor.getValue().status().reasonPhrase(),
+    assertThat(messageArgumentCaptor.getValue().payload().get().utf8(),
                not(containsString("\n")));
   }
 
@@ -180,7 +180,7 @@ public class EndpointInvocationHandlerTest {
 
     verify(ongoingRequest).reply(messageArgumentCaptor.capture());
 
-    assertThat(messageArgumentCaptor.getValue().status().reasonPhrase(),
+    assertThat(messageArgumentCaptor.getValue().payload().get().utf8(),
         containsString(exception.getMessage()));
   }
 


### PR DESCRIPTION
This should make it easier to see error messages. Using HTTP status reason phrases for communicating anything more than the nature of the error seems to be a bit exotic too.