### PR TITLE
Support config for defining Jetty Server max threads

### DIFF
--- a/modules/jetty-http-server/README.md
+++ b/modules/jetty-http-server/README.md
@@ -9,6 +9,7 @@ key | type | required | note
 `http.server.port` | int | optional | ie 8080
 `http.server.address` | string | optional | default 0.0.0.0
 `http.server.ttlMillis` | int | optional | default 30000, determines how long before an error response is sent
+`http.server.maxThreads` | int | optional | default 200, determines the maximum number of threads in the server thread pool 
 
 ## Special request headers
 

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerConfig.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerConfig.java
@@ -31,6 +31,7 @@ class HttpServerConfig {
   private static final String CONFIG_BASE_NAME = "http.server";
   private static final String DEFAULT_HTTP_ADDRESS = "0.0.0.0";
   private static final int DEFAULT_TTL_MILLIS = 30000;
+  private static final int DEFAULT_MAX_THREADS = 200;
 
   private final Config config;
 
@@ -49,5 +50,9 @@ class HttpServerConfig {
 
   public long ttlMillis() {
     return optionalInt(config, CONFIG_BASE_NAME + ".ttlMillis").orElse(DEFAULT_TTL_MILLIS);
+  }
+
+  public int maxThreads() {
+    return optionalInt(config, CONFIG_BASE_NAME + ".maxThreads").orElse(DEFAULT_MAX_THREADS);
   }
 }

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerImpl.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerImpl.java
@@ -19,6 +19,7 @@
  */
 package com.spotify.apollo.http.server;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Closer;
 
 import com.spotify.apollo.RequestMetadata;
@@ -26,6 +27,7 @@ import com.spotify.apollo.request.RequestHandler;
 import com.spotify.apollo.request.RequestMetadataImpl;
 
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +46,8 @@ class HttpServerImpl implements HttpServer {
   private final Runnable onClose;
   private final RequestOutcomeConsumer logger;
 
-  private Server server;
+  @VisibleForTesting
+  Server server;
 
   HttpServerImpl(Closer closer, HttpServerConfig config, Runnable onClose,
                  RequestOutcomeConsumer logger) {
@@ -63,6 +66,8 @@ class HttpServerImpl implements HttpServer {
         RequestMetadataImpl.hostAndPort(config.address(), config.port());
 
     server = new Server(serverSocketAddress);
+    ((QueuedThreadPool) server.getThreadPool()).setMaxThreads(config.maxThreads());
+
     server.setHandler(new ApolloRequestHandler(serverInfo, requestHandler,
                                                Duration.ofMillis(config.ttlMillis()), logger));
     try {

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/common/TestHandler.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/common/TestHandler.java
@@ -1,3 +1,22 @@
+/*
+ * -\-\-
+ * Spotify Apollo Jetty HTTP Server Module
+ * --
+ * Copyright (C) 2013 - 2015 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *      http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
 package com.spotify.apollo.http.common;
 
 import static com.spotify.apollo.Status.IM_A_TEAPOT;

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/common/TestHandler.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/common/TestHandler.java
@@ -1,0 +1,24 @@
+package com.spotify.apollo.http.common;
+
+import static com.spotify.apollo.Status.IM_A_TEAPOT;
+
+import com.google.common.collect.Lists;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.request.OngoingRequest;
+import com.spotify.apollo.request.RequestHandler;
+import java.util.List;
+
+public class TestHandler implements RequestHandler {
+
+    List<OngoingRequest> requests = Lists.newLinkedList();
+
+    @Override
+    public void handle(OngoingRequest request) {
+      requests.add(request);
+      request.reply(Response.forStatus(IM_A_TEAPOT));
+    }
+
+  public List<OngoingRequest> getRequests() {
+    return requests;
+  }
+}

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerConfigTest.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerConfigTest.java
@@ -48,6 +48,15 @@ public class HttpServerConfigTest {
     assertEquals(ttlMillis, http.ttlMillis());
   }
 
+  @Test
+  public void canConfigureMaxThreads() {
+    long maxThreads = 3900;
+    String json = "{\"http\":{\"server\":{\"maxThreads\": 3900}}}";
+
+    HttpServerConfig http = conf(json);
+    assertEquals(maxThreads, http.maxThreads());
+  }
+
   private static HttpServerConfig conf(String json) {
     return new HttpServerConfig(ConfigFactory.parseString(json));
   }

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerImplTest.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerImplTest.java
@@ -1,3 +1,22 @@
+/*
+ * -\-\-
+ * Spotify Apollo Jetty HTTP Server Module
+ * --
+ * Copyright (C) 2013 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *      http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
 package com.spotify.apollo.http.server;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerImplTest.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerImplTest.java
@@ -1,0 +1,51 @@
+package com.spotify.apollo.http.server;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.spotify.apollo.core.Service;
+import com.spotify.apollo.core.Services;
+import com.spotify.apollo.http.common.TestHandler;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.io.IOException;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.junit.Test;
+
+public class HttpServerImplTest {
+
+  Config withMaxThreads(int maxThreads, int port) {
+    return ConfigFactory.parseMap(
+        ImmutableMap.of(
+            "http.server.maxThreads", Integer.toString(maxThreads),
+            "http.server.port", Integer.toString(port)
+        )
+    );
+  }
+
+  @Test
+  public void setsMaxThreadsOnJettyServer() throws IOException {
+    int maxThreads = 30;
+    int port = 9086;
+
+    final Service service = Services.usingName("test")
+        .withModule(HttpServerModule.create())
+        .build();
+
+    Service.Instance instance = service.start(new String[0], withMaxThreads(maxThreads,port));
+
+    try {
+      HttpServerImpl server = (HttpServerImpl) HttpServerModule.server(instance);
+      TestHandler testHandler = new TestHandler();
+
+      server.start(testHandler);
+
+      QueuedThreadPool threadPool = (QueuedThreadPool) server.server.getThreadPool();
+      assertThat(threadPool.getMaxThreads(), is(maxThreads));
+      server.close();
+    } finally {
+      instance.close();
+    }
+  }
+}

--- a/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerModuleTest.java
+++ b/modules/jetty-http-server/src/test/java/com/spotify/apollo/http/server/HttpServerModuleTest.java
@@ -19,13 +19,10 @@
  */
 package com.spotify.apollo.http.server;
 
-import com.google.common.collect.Lists;
-
-import com.spotify.apollo.Response;
 import com.spotify.apollo.core.Service;
 import com.spotify.apollo.core.Services;
+import com.spotify.apollo.http.common.TestHandler;
 import com.spotify.apollo.request.OngoingRequest;
-import com.spotify.apollo.request.RequestHandler;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
@@ -36,7 +33,6 @@ import org.junit.rules.ExpectedException;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.Socket;
-import java.util.List;
 import java.util.Optional;
 
 import okhttp3.OkHttpClient;
@@ -79,8 +75,8 @@ public class HttpServerModuleTest {
       okhttp3.Response response = okHttpClient.newCall(request).execute();
       assertThat(response.code(), is(IM_A_TEAPOT.code()));
 
-      assertThat(testHandler.requests.size(), is(1));
-      OngoingRequest incomingRequest = testHandler.requests.get(0);
+      assertThat(testHandler.getRequests().size(), is(1));
+      OngoingRequest incomingRequest = testHandler.getRequests().get(0);
       assertThat(incomingRequest.request().uri(), is("/hello/world"));
 
       server.close();
@@ -104,8 +100,8 @@ public class HttpServerModuleTest {
       okhttp3.Response response = okHttpClient.newCall(httpRequest).execute();
       assertThat(response.code(), is(IM_A_TEAPOT.code()));
 
-      assertThat(testHandler.requests.size(), is(1));
-      final com.spotify.apollo.Request apolloRequest = testHandler.requests.get(0).request();
+      assertThat(testHandler.getRequests().size(), is(1));
+      final com.spotify.apollo.Request apolloRequest = testHandler.getRequests().get(0).request();
       assertThat(apolloRequest.uri(), is("/query?a=foo&b=bar&b=baz"));
       assertThat(apolloRequest.parameter("a"), is(Optional.of("foo")));
       assertThat(apolloRequest.parameter("b"), is(Optional.of("bar")));
@@ -133,8 +129,8 @@ public class HttpServerModuleTest {
       okhttp3.Response response = okHttpClient.newCall(httpRequest).execute();
       assertThat(response.code(), is(IM_A_TEAPOT.code()));
 
-      assertThat(testHandler.requests.size(), is(1));
-      final com.spotify.apollo.Request apolloRequest = testHandler.requests.get(0).request();
+      assertThat(testHandler.getRequests().size(), is(1));
+      final com.spotify.apollo.Request apolloRequest = testHandler.getRequests().get(0).request();
       assertThat(apolloRequest.uri(), is("/headers"));
       assertThat(apolloRequest.header("Foo"), is(Optional.of("bar")));
       assertThat(apolloRequest.header("Repeat"), is(Optional.of("once,twice")));
@@ -169,17 +165,6 @@ public class HttpServerModuleTest {
       fail();
     } catch (ConnectException e) {
       assertThat(e.getMessage(), containsString("Connection refused"));
-    }
-  }
-
-  private static class TestHandler implements RequestHandler {
-
-    List<OngoingRequest> requests = Lists.newLinkedList();
-
-    @Override
-    public void handle(OngoingRequest request) {
-      requests.add(request);
-      request.reply(Response.forStatus(IM_A_TEAPOT));
     }
   }
 }


### PR DESCRIPTION
Currently, we don't have any way of setting the `maxThreads` config for the Jetty server.

They are [capped at 200](https://github.com/eclipse/jetty.project/blob/jetty-9.4.8.v20171121/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java#L72) since we don't provide any value when we [initialize it](https://github.com/eclipse/jetty.project/blob/jetty-9.4.8.v20171121/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java#L134).

We should provide a way for webapp owners to be able to define this limit as 200 might not be suitable for all apps. See [Jetty's documentation](https://wiki.eclipse.org/Jetty/Howto/High_Load#Jetty_Tuning) for more details.