### PR TITLE
fix Maven warnings about missing maven-surefire-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,9 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.1</version>
+                <configuration>
+                  <useSystemClassLoader>false</useSystemClassLoader>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>


### PR DESCRIPTION
The root pom does not define a version for maven-surefire-plugin, which
this pom seems to assume.

> [WARNING] Some problems were encountered while building the effective model for com.spotify:apollo-bom:pom:1.8.1-SNAPSHOT
> [WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ com.spotify:apollo-parent:1.8.1-SNAPSHOT, /root/apollo/pom.xml, line 137, column 21