### PR TITLE
Bump guava to 26.0

### DIFF
--- a/apollo-api/src/main/java/com/spotify/apollo/route/Middleware.java
+++ b/apollo-api/src/main/java/com/spotify/apollo/route/Middleware.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import static com.google.common.util.concurrent.Futures.addCallback;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 /**
@@ -59,7 +60,8 @@ public interface Middleware<H, T> extends Function<H, T> {
             public void onFailure(Throwable t) {
               future.completeExceptionally(t);
             }
-          });
+          },
+          directExecutor());
 
       return future;
     };

--- a/apollo-bom/pom.xml
+++ b/apollo-bom/pom.xml
@@ -135,7 +135,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>23.6-jre</version>
+                <version>26.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>

--- a/apollo-extra/src/main/java/com/spotify/apollo/concurrent/Util.java
+++ b/apollo-extra/src/main/java/com/spotify/apollo/concurrent/Util.java
@@ -19,6 +19,8 @@
  */
 package com.spotify.apollo.concurrent;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -49,7 +51,8 @@ public final class Util {
                           public void onFailure(Throwable t) {
                             completableFuture.completeExceptionally(t);
                           }
-                        });
+                        },
+                        directExecutor());
 
     return completableFuture;
   }

--- a/apollo-test/src/main/java/com/spotify/apollo/test/experimental/ResponseTimeMetric.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/experimental/ResponseTimeMetric.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.util.concurrent.Futures.addCallback;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.lang.System.nanoTime;
 
 public class ResponseTimeMetric {
@@ -66,7 +67,7 @@ public class ResponseTimeMetric {
   }
 
   public <T> void track(final ListenableFuture<T> future, final long t0, final int rate) {
-    addCallback(future, createCallback(t0, rate));
+    addCallback(future, createCallback(t0, rate), directExecutor());
   }
 
   private <T> FutureCallback<T> createCallback(final long t0, final int rate) {

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,15 @@
                         <useSystemClassLoader>false</useSystemClassLoader>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.22.1</version>
+                    <configuration>
+                        <!-- To avoid ForkedBooter loading issue -->
+                        <useSystemClassLoader>false</useSystemClassLoader>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,15 @@
                     <artifactId>maven-site-plugin</artifactId>
                     <version>3.3</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.1</version>
+                    <configuration>
+                        <!-- To avoid ForkedBooter loading issue -->
+                        <useSystemClassLoader>false</useSystemClassLoader>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
- Update guava version in bom to 26.0-jre
- Fix resulting errors caused by deprecation of addCallback with implicit executor  