### PR TITLE
upgrade jackson and jetty-server to deal with CVEs

### DIFF
--- a/apollo-bom/pom.xml
+++ b/apollo-bom/pom.xml
@@ -125,12 +125,12 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.6.1</version>
+                <version>2.8.11.1</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.6.1</version>
+                <version>2.8.11</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -197,7 +197,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
-                <version>9.3.4.v20151007</version>
+                <version>9.3.24.v20180605</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Found these via the Github vulnerability feature.

For org.eclipse.jetty:jetty-server:
- https://nvd.nist.gov/vuln/detail/CVE-2017-7656 (moderate)
- https://nvd.nist.gov/vuln/detail/CVE-2017-9735 (moderate)
- https://nvd.nist.gov/vuln/detail/CVE-2018-12536 (moderate)
- https://nvd.nist.gov/vuln/detail/CVE-2017-7657 (critical)
- https://nvd.nist.gov/vuln/detail/CVE-2016-4800 (high)

For com.fasterxml.jackson.core:jackson-databind:

- https://nvd.nist.gov/vuln/detail/CVE-2017-17485 (high)
- https://nvd.nist.gov/vuln/detail/CVE-2018-7489 (high)
- https://nvd.nist.gov/vuln/detail/CVE-2017-7525 (high)