### PR TITLE
[metrics] bump version

### DIFF
--- a/modules/metrics/pom.xml
+++ b/modules/metrics/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <semantic-metrics.version>0.11.4</semantic-metrics.version>
+        <semantic-metrics.version>1.0.1</semantic-metrics.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Version 1.0.1 supports Java 11 since it now uses the latest version of`io.dropwizard.metrics`.



@tommyulfsparre @mattnworb 