### PR TITLE
[metrics] change default histogram reservoir

### DIFF
--- a/modules/metrics/README.md
+++ b/modules/metrics/README.md
@@ -6,6 +6,10 @@ with the Apollo request/response handling facilities.
 Including this this module in your assembly means that Apollo will add some metrics tracking
 requests per endpoint.
 
+
+A *note* on histograms. This metrics module now uses a [ReservoirWithTtl](https://github.com/spotify/semantic-metrics/tree/9b51f4f6febe7ca251c9410592324645bdb87d6a#histogram-with-ttl) as the **default** reservoir for histograms. This eliminates the impact of latencies like p99 being stuck when instances are drained of traffic or the request throughput of a service or endpoint are low.
+
+
 ## Metrics
 
 All metrics will be tagged with the following tags:
@@ -121,6 +125,7 @@ A Meter, tagged with:
 This meter will only be created if a duration goal is set in the configuration (`endpoint-duration-goal`). The meter will be marked when a request meets its goal.
 
 
+
 ## [ffwd](https://github.com/spotify/ffwd) reporter
 
 The metrics module includes the [ffwd reporter](https://github.com/spotify/semantic-metrics#provided-plugins)
@@ -132,6 +137,7 @@ key | type | required | note
 --- | ---- | -------- | ----
 `metrics.server` | string list | optional | list of [`What`](src/main/java/com/spotify/apollo/metrics/semantic/What.java) names to enable; defaults to [ENDPOINT_REQUEST_RATE, ENDPOINT_REQUEST_DURATION, DROPPED_REQUEST_RATE, ERROR_RATIO]
 `metrics.precreate-codes` | int list | optional | list of status codes to precreate request-rate meters for, default empty
+`metrics.reservoir-ttl` | int | optional | When to purge old values from the histogram, defaults to 300 seconds. Note, setting this to a large value will increase the amount of memory used to keep track samples.
 `ffwd.type` | string | optional | indicates which type of ffwd reporter to use. Available types are `agent` and `http`. see below for details. default is `agent`.
 `endpoint-duration-goal`  | int map  | optional |  sets request duration thresholds in milliseconds to track how many requests meet a duration objective
 

--- a/modules/metrics/pom.xml
+++ b/modules/metrics/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <semantic-metrics.version>1.0.1</semantic-metrics.version>
+        <semantic-metrics.version>1.0.2</semantic-metrics.version>
     </properties>
 
     <dependencyManagement>

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsModule.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsModule.java
@@ -35,6 +35,7 @@ import com.spotify.apollo.metrics.semantic.SemanticMetricsFactory;
 import com.spotify.apollo.module.AbstractApolloModule;
 import com.spotify.apollo.module.ApolloModule;
 import com.spotify.metrics.core.MetricId;
+import com.spotify.metrics.core.ReservoirWithTtl;
 import com.spotify.metrics.core.SemanticMetricRegistry;
 import com.spotify.metrics.core.SemanticMetricSet;
 import com.spotify.metrics.ffwd.FastForwardReporter;
@@ -86,8 +87,11 @@ public class MetricsModule extends AbstractApolloModule {
 
   @Provides
   @Singleton
-  public SemanticMetricRegistry semanticMetricRegistry() {
-    final SemanticMetricRegistry metricRegistry = new SemanticMetricRegistry();
+  public SemanticMetricRegistry semanticMetricRegistry(MetricsConfig metricsConfig) {
+    final SemanticMetricRegistry metricRegistry = new SemanticMetricRegistry(
+      () -> new ReservoirWithTtl(metricsConfig.reservoirTtl()));
+
+
     LOG.info("Creating SemanticMetricRegistry");
 
     // register JVM metricSets, using an empty MetricId as the FastForwardReporter will prepend

--- a/modules/metrics/src/test/java/com/spotify/apollo/metrics/semantic/HistogramExpirationTest.java
+++ b/modules/metrics/src/test/java/com/spotify/apollo/metrics/semantic/HistogramExpirationTest.java
@@ -1,0 +1,76 @@
+/*
+ * -\-\-
+ * Spotify Apollo Metrics Module
+ * --
+ * Copyright (C) 2013 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.metrics.semantic;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.codahale.metrics.Histogram;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.metrics.RequestMetrics;
+import com.spotify.metrics.core.MetricId;
+import com.spotify.metrics.core.ReservoirWithTtl;
+import com.spotify.metrics.core.SemanticMetricRegistry;
+import com.typesafe.config.ConfigFactory;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import okio.ByteString;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HistogramExpirationTest {
+  private static int RESERVOIR_TTL_SECONDS = 1;
+
+  private SemanticMetricRegistry metricRegistry;
+
+  private RequestMetrics requestMetrics;
+
+  @Before
+  public void setUp() {
+    metricRegistry = new SemanticMetricRegistry(() -> new ReservoirWithTtl(RESERVOIR_TTL_SECONDS));
+
+    SemanticServiceMetrics serviceMetrics = new SemanticServiceMetrics(
+      metricRegistry,
+      MetricId.EMPTY,
+      Collections.emptySet(),
+      what -> true,
+      DurationThresholdConfig.parseConfig(ConfigFactory.empty())
+    );
+
+    requestMetrics = serviceMetrics.metricsForEndpointCall("GET:/bar");
+  }
+
+  @Test
+  public void shouldExpireOldValues() throws InterruptedException {
+    requestMetrics.response(Response.forPayload(ByteString.of("huge-payload!".getBytes())));
+
+    final Optional<Histogram> payloadSize = metricRegistry.getHistograms().entrySet().stream()
+      .filter((entry) -> entry.getKey().getTags().get("what").equals("response-payload-size"))
+      .map(Map.Entry::getValue)
+      .findFirst();
+
+    assertThat(payloadSize.isPresent(), is(true));
+    assertThat(payloadSize.get().getSnapshot().get99thPercentile(), is(13D));
+    // Sucks that we have to sleep in a unit test but I can't think of another way to test this.
+    Thread.sleep(1500L);
+    assertThat(payloadSize.get().getSnapshot().get99thPercentile(), is(0D));
+  }
+}

--- a/modules/metrics/src/test/java/com/spotify/apollo/metrics/semantic/MetricsConfigTest.java
+++ b/modules/metrics/src/test/java/com/spotify/apollo/metrics/semantic/MetricsConfigTest.java
@@ -19,22 +19,30 @@
  */
 package com.spotify.apollo.metrics.semantic;
 
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-
-import org.junit.Test;
-
-import java.util.EnumSet;
-
-import com.google.common.collect.Sets;
-
 import static com.spotify.apollo.metrics.semantic.What.ENDPOINT_REQUEST_DURATION;
 import static com.spotify.apollo.metrics.semantic.What.ENDPOINT_REQUEST_RATE;
 import static com.spotify.apollo.metrics.semantic.What.REQUEST_PAYLOAD_SIZE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.Sets;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.EnumSet;
+import org.junit.Test;
+
 public class MetricsConfigTest {
+
+  @Test
+  public void testDefaultreservoirTtl() {
+    assertThat(new MetricsConfig(ConfigFactory.empty()).reservoirTtl(), is(300));
+  }
+
+  @Test
+  public void testOverrideDefaultreservoirTtl() {
+    assertThat(new MetricsConfig(ConfigFactory.parseString(
+      "metrics.reservoir-ttl: 30")).reservoirTtl(), is(30));
+  }
 
   @Test
   public void shouldReturnDefaultIfNoConfig() throws Exception {


### PR DESCRIPTION
This changes the default histogram reservoir to a [ReservoirWithTtl](https://github.com/spotify/semantic-metrics/tree/9b51f4f6febe7ca251c9410592324645bdb87d6a#histogram-with-ttl).

This eliminates the impact of latencies like p99 being stuck when instances are drained of traffic or the request throughput of a service or endpoint are low.

This is reservoir has already been battle tested internally by being used in Hermes for server metrics.

Would appreciate having this released once merged... we have some people eagerly awaiting this change. 

@tommyulfsparre @jsferrei 
