### PR TITLE
Removing unused dependency.

### DIFF
--- a/apollo-bom/pom.xml
+++ b/apollo-bom/pom.xml
@@ -177,11 +177,6 @@
                 <artifactId>commons-io</artifactId>
                 <version>2.4</version>
             </dependency>
-            <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>2.6</version>
-            </dependency>
 
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/apollo-route/pom.xml
+++ b/apollo-route/pom.xml
@@ -40,10 +40,6 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>


### PR DESCRIPTION
Only `commons-lang3` is actually used, outdated version `2.6` is never used and is not required as a transitive dependency.