### PR TITLE
Enable auto discovery

### DIFF
--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsModule.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsModule.java
@@ -65,8 +65,8 @@ public class MetricsModule extends AbstractApolloModule {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetricsModule.class);
 
-  private MetricsModule() {
-    // prevent external instantiation
+  // Visible for SPI support
+  public MetricsModule() {
   }
 
   public static MetricsModule create() {

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsModule.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsModule.java
@@ -65,7 +65,7 @@ public class MetricsModule extends AbstractApolloModule {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetricsModule.class);
 
-  // Visible for SPI support
+  // Should not be used, only here to be visible for SPI support.
   public MetricsModule() {
   }
 


### PR DESCRIPTION
All modules marked @AutoService(ApolloModule.class) must have a public constructor or boot will fail when running with enabled discovery.