### PR TITLE
Update comment for public constructor

### DIFF
--- a/modules/slack/src/main/java/com/spotify/apollo/slack/SlackModule.java
+++ b/modules/slack/src/main/java/com/spotify/apollo/slack/SlackModule.java
@@ -31,7 +31,7 @@ public class SlackModule extends AbstractApolloModule {
 
   private final Class<? extends Provider<? extends Slack>> slackProvider;
 
-  // Visible for SPI support
+  // Should not be used, only here to be visible for SPI support.
   public SlackModule() {
     slackProvider = SlackProvider.class;
   }


### PR DESCRIPTION
Update comment to indicate that public constructor should not be used except by SPI
Similar to change in #274