### PR TITLE
Bump version of okio

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
             <dependency>
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio</artifactId>
-                <version>1.6.0</version>
+                <version>1.14.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>


### PR DESCRIPTION
A later version of okio is used within a tracing library to avoid the need for pinning the dependency bump the version to match what that library uses.