### PR TITLE
Update Mockito, remove javax.inject

### DIFF
--- a/apollo-api-impl/pom.xml
+++ b/apollo-api-impl/pom.xml
@@ -122,11 +122,6 @@
             <artifactId>jmh-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-generator-annprocess</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/dispatch/EndpointInvocationHandlerTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/dispatch/EndpointInvocationHandlerTest.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.helpers.MessageFormatter;
 
 import uk.org.lidalia.slf4jext.Level;
@@ -85,7 +85,6 @@ public class EndpointInvocationHandlerTest {
     Request requestMessage = Request.forUri("http://foo/bar").withService("nameless-registry");
 
     when(ongoingRequest.request()).thenReturn(requestMessage);
-    when(requestContext.request()).thenReturn(requestMessage);
     future = new CompletableFuture<>();
   }
 

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/request/GatheringEndpointRunnableFactoryTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/request/GatheringEndpointRunnableFactoryTest.java
@@ -19,7 +19,6 @@
  */
 package com.spotify.apollo.request;
 
-import com.spotify.apollo.Request;
 import com.spotify.apollo.RequestContext;
 import com.spotify.apollo.dispatch.Endpoint;
 import com.spotify.apollo.dispatch.EndpointInfo;
@@ -29,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -53,10 +52,6 @@ public class GatheringEndpointRunnableFactoryTest {
 
   @Before
   public void setUp() throws Exception {
-    when(ongoingRequest.request()).thenReturn(Request.forUri("http://foo"));
-    when(endpoint.info()).thenReturn(info);
-    when(info.getName()).thenReturn("foo");
-
     when(delegate.create(any(), any(), any())).thenReturn(delegateRunnable);
 
     endpointRunnableFactory = new GatheringEndpointRunnableFactory(

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/request/RequestHandlerImplTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/request/RequestHandlerImplTest.java
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -88,8 +88,6 @@ public class RequestHandlerImplTest {
         .thenReturn(runnable);
 
     when(match.getRule()).thenReturn(Rule.fromUri("http://foo", "GET", endpoint));
-    when(endpoint.info()).thenReturn(info);
-    when(info.getName()).thenReturn("foo");
 
     requestHandler = new RequestHandlerImpl(requestFactory, endpointFactory, client);
   }

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/request/RequestRunnableImplTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/request/RequestRunnableImplTest.java
@@ -25,7 +25,6 @@ import com.spotify.apollo.Status;
 import com.spotify.apollo.dispatch.Endpoint;
 import com.spotify.apollo.dispatch.EndpointInfo;
 import com.spotify.apollo.route.ApplicationRouter;
-import com.spotify.apollo.route.Rule;
 import com.spotify.apollo.route.RuleMatch;
 
 import org.junit.Before;
@@ -34,7 +33,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Collections;
@@ -73,9 +72,6 @@ public class RequestRunnableImplTest {
   @Before
   public void setUp() throws Exception {
     when(applicationRouter.match(any(Request.class))).thenReturn(Optional.of(match));
-    when(match.getRule()).thenReturn(Rule.fromUri("http://foo", "GET", endpoint));
-    when(endpoint.info()).thenReturn(info);
-    when(info.getName()).thenReturn("foo");
     when(ongoingRequest.request()).thenReturn(message);
 
     requestRunnable = new RequestRunnableImpl(ongoingRequest, applicationRouter);

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/request/RequestTrackerTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/request/RequestTrackerTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import okio.ByteString;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.mockito.Matchers.argThat;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/request/TrackedOngoingRequestImplTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/request/TrackedOngoingRequestImplTest.java
@@ -19,19 +19,16 @@
  */
 package com.spotify.apollo.request;
 
-import com.spotify.apollo.Request;
 import com.spotify.apollo.Response;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TrackedOngoingRequestImplTest {
@@ -40,12 +37,6 @@ public class TrackedOngoingRequestImplTest {
   @Mock RequestTracker requestTracker;
 
   RequestTracker tracker = new RequestTracker();
-
-  @Before
-  public void setUp() throws Exception {
-    when(ongoingRequest.request()).thenReturn(Request.forUri("http://service/path"));
-    when(ongoingRequest.isExpired()).thenReturn(false);
-  }
 
   @Test
   public void shouldRegisterWithRequestTracker() throws Exception {

--- a/apollo-api-impl/src/test/java/com/spotify/apollo/request/TrackingEndpointRunnableFactoryTest.java
+++ b/apollo-api-impl/src/test/java/com/spotify/apollo/request/TrackingEndpointRunnableFactoryTest.java
@@ -19,7 +19,6 @@
  */
 package com.spotify.apollo.request;
 
-import com.spotify.apollo.Request;
 import com.spotify.apollo.RequestContext;
 import com.spotify.apollo.dispatch.Endpoint;
 import com.spotify.apollo.dispatch.EndpointInfo;
@@ -29,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -54,10 +53,6 @@ public class TrackingEndpointRunnableFactoryTest {
 
   @Before
   public void setUp() throws Exception {
-    when(ongoingRequest.request()).thenReturn(Request.forUri("http://foo"));
-    when(endpoint.info()).thenReturn(info);
-    when(info.getName()).thenReturn("foo");
-
     when(delegate.create(any(), any(), any())).thenReturn(delegateRunnable);
 
     endpointRunnableFactory = new TrackingEndpointRunnableFactory(

--- a/apollo-core/pom.xml
+++ b/apollo-core/pom.xml
@@ -34,10 +34,6 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/apollo-core/src/test/java/com/spotify/apollo/core/ModuleWithLifecycledKeys.java
+++ b/apollo-core/src/test/java/com/spotify/apollo/core/ModuleWithLifecycledKeys.java
@@ -20,6 +20,7 @@
 package com.spotify.apollo.core;
 
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 
 import com.spotify.apollo.module.AbstractApolloModule;
@@ -27,8 +28,6 @@ import com.spotify.apollo.module.AbstractApolloModule;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.inject.Named;
 
 class ModuleWithLifecycledKeys extends AbstractApolloModule {
 

--- a/apollo-environment/pom.xml
+++ b/apollo-environment/pom.xml
@@ -59,10 +59,6 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/apollo-environment/src/main/java/com/spotify/apollo/environment/ApolloConfig.java
+++ b/apollo-environment/src/main/java/com/spotify/apollo/environment/ApolloConfig.java
@@ -19,12 +19,11 @@
  */
 package com.spotify.apollo.environment;
 
+import com.google.inject.Inject;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import java.util.Objects;
-
-import javax.inject.Inject;
 
 import static com.spotify.apollo.environment.ConfigUtil.either;
 import static com.spotify.apollo.environment.ConfigUtil.optionalBoolean;

--- a/apollo-environment/src/main/java/com/spotify/apollo/environment/ApolloEnvironmentModule.java
+++ b/apollo-environment/src/main/java/com/spotify/apollo/environment/ApolloEnvironmentModule.java
@@ -22,6 +22,7 @@ package com.spotify.apollo.environment;
 import com.google.common.collect.Iterables;
 import com.google.common.io.Closer;
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
 
 import com.spotify.apollo.AppInit;
@@ -46,8 +47,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Set;
 import java.util.function.Function;
-
-import javax.inject.Singleton;
 
 import static com.spotify.apollo.request.Handlers.endpointRunnableFactory;
 import static com.spotify.apollo.request.Handlers.requestHandler;

--- a/apollo-environment/src/main/java/com/spotify/apollo/environment/EnvironmentModule.java
+++ b/apollo-environment/src/main/java/com/spotify/apollo/environment/EnvironmentModule.java
@@ -23,6 +23,7 @@ import com.google.common.io.Closer;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 
 import com.spotify.apollo.Client;
@@ -34,8 +35,6 @@ import com.spotify.apollo.meta.MetaInfoTracker;
 import com.typesafe.config.Config;
 
 import java.util.Set;
-
-import javax.inject.Singleton;
 
 import static com.spotify.apollo.environment.ApolloEnvironmentModule.foldDecorators;
 

--- a/apollo-environment/src/main/java/com/spotify/apollo/environment/MetaModule.java
+++ b/apollo-environment/src/main/java/com/spotify/apollo/environment/MetaModule.java
@@ -21,6 +21,7 @@ package com.spotify.apollo.environment;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 
 import com.spotify.apollo.core.Services;
@@ -29,8 +30,6 @@ import com.spotify.apollo.meta.MetaInfoTracker;
 import com.typesafe.config.Config;
 
 import java.io.IOException;
-
-import javax.inject.Singleton;
 
 /**
  * Module for setting up service metadata collection objects.

--- a/apollo-http-service/src/main/java/com/spotify/apollo/httpservice/MetricIdModule.java
+++ b/apollo-http-service/src/main/java/com/spotify/apollo/httpservice/MetricIdModule.java
@@ -25,11 +25,10 @@ package com.spotify.apollo.httpservice;
 
 import com.google.inject.Provides;
 
+import com.google.inject.Singleton;
 import com.spotify.apollo.meta.MetaDescriptor;
 import com.spotify.apollo.module.AbstractApolloModule;
 import com.spotify.metrics.core.MetricId;
-
-import javax.inject.Singleton;
 
 class MetricIdModule extends AbstractApolloModule {
 

--- a/apollo-test/pom.xml
+++ b/apollo-test/pom.xml
@@ -103,10 +103,6 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
 
         <!--test dependencies-->
         <dependency>

--- a/apollo-test/src/main/java/com/spotify/apollo/test/ServiceHelper.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/ServiceHelper.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Provides;
 
+import com.google.inject.Singleton;
 import com.spotify.apollo.AppInit;
 import com.spotify.apollo.Client;
 import com.spotify.apollo.Environment;
@@ -67,8 +68,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-
-import javax.inject.Singleton;
 
 import okio.ByteString;
 

--- a/examples/brewery/pom.xml
+++ b/examples/brewery/pom.xml
@@ -49,7 +49,6 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerConfig.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerConfig.java
@@ -19,9 +19,8 @@
  */
 package com.spotify.apollo.http.server;
 
+import com.google.inject.Inject;
 import com.typesafe.config.Config;
-
-import javax.inject.Inject;
 
 import static com.spotify.apollo.environment.ConfigUtil.optionalInt;
 import static com.spotify.apollo.environment.ConfigUtil.optionalString;

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerModule.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerModule.java
@@ -20,14 +20,13 @@
 package com.spotify.apollo.http.server;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 
 import com.spotify.apollo.core.Service;
 import com.spotify.apollo.module.AbstractApolloModule;
 
 import java.util.Objects;
-
-import javax.inject.Singleton;
 
 public class HttpServerModule extends AbstractApolloModule {
 

--- a/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerProvider.java
+++ b/modules/jetty-http-server/src/main/java/com/spotify/apollo/http/server/HttpServerProvider.java
@@ -22,13 +22,12 @@ package com.spotify.apollo.http.server;
 import com.google.common.io.Closer;
 import com.google.inject.Inject;
 
+import com.google.inject.Provider;
+import com.google.inject.name.Named;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-
-import javax.inject.Named;
-import javax.inject.Provider;
 
 import static java.util.Objects.requireNonNull;
 

--- a/modules/metrics/pom.xml
+++ b/modules/metrics/pom.xml
@@ -87,10 +87,6 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
         </dependency>

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsCollectingEndpointRunnableFactoryDecorator.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsCollectingEndpointRunnableFactoryDecorator.java
@@ -19,14 +19,13 @@
  */
 package com.spotify.apollo.metrics;
 
+import com.google.inject.Inject;
 import com.spotify.apollo.Client;
 import com.spotify.apollo.RequestContext;
 import com.spotify.apollo.environment.EndpointRunnableFactoryDecorator;
 import com.spotify.apollo.request.EndpointRunnableFactory;
 import com.spotify.apollo.request.RequestContexts;
 import com.spotify.apollo.request.TrackedOngoingRequest;
-
-import javax.inject.Inject;
 
 /**
  * An {@link EndpointRunnableFactory} that collects metrics

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsModule.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsModule.java
@@ -27,6 +27,7 @@ import com.google.auto.service.AutoService;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Named;
 import com.spotify.apollo.core.Services;
 import com.spotify.apollo.environment.ApolloConfig;
 import com.spotify.apollo.environment.EndpointRunnableFactoryDecorator;
@@ -47,7 +48,6 @@ import com.typesafe.config.Config;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import javax.inject.Named;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/MetricsConfig.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/MetricsConfig.java
@@ -26,6 +26,7 @@ import static com.spotify.apollo.metrics.semantic.What.ENDPOINT_REQUEST_DURATION
 import static com.spotify.apollo.metrics.semantic.What.ENDPOINT_REQUEST_RATE;
 import static com.spotify.apollo.metrics.semantic.What.ERROR_RATIO;
 
+import com.google.inject.Inject;
 import com.typesafe.config.Config;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -33,7 +34,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import javax.inject.Inject;
 
 public class MetricsConfig {
 

--- a/modules/okhttp-client/pom.xml
+++ b/modules/okhttp-client/pom.xml
@@ -59,10 +59,6 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.squareup.okio</groupId>
             <artifactId>okio</artifactId>
         </dependency>

--- a/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClient.java
+++ b/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClient.java
@@ -19,6 +19,7 @@
  */
 package com.spotify.apollo.http.client;
 
+import com.google.inject.Inject;
 import com.spotify.apollo.environment.IncomingRequestAwareClient;
 
 import com.squareup.okhttp.Headers;
@@ -31,8 +32,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-
-import javax.inject.Inject;
 
 import okio.ByteString;
 

--- a/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClientDecorator.java
+++ b/modules/okhttp-client/src/main/java/com/spotify/apollo/http/client/HttpClientDecorator.java
@@ -19,10 +19,9 @@
  */
 package com.spotify.apollo.http.client;
 
+import com.google.inject.Inject;
 import com.spotify.apollo.environment.ClientDecorator;
 import com.spotify.apollo.environment.IncomingRequestAwareClient;
-
-import javax.inject.Inject;
 
 class HttpClientDecorator implements ClientDecorator {
 

--- a/modules/slack/src/main/java/com/spotify/apollo/slack/SlackModule.java
+++ b/modules/slack/src/main/java/com/spotify/apollo/slack/SlackModule.java
@@ -21,10 +21,9 @@ package com.spotify.apollo.slack;
 
 import com.google.auto.service.AutoService;
 
+import com.google.inject.Provider;
 import com.spotify.apollo.module.AbstractApolloModule;
 import com.spotify.apollo.module.ApolloModule;
-
-import javax.inject.Provider;
 
 @AutoService(ApolloModule.class)
 public class SlackModule extends AbstractApolloModule {

--- a/pom.xml
+++ b/pom.xml
@@ -93,11 +93,6 @@
                 <version>1.14.0</version>
             </dependency>
             <dependency>
-                <groupId>javax.inject</groupId>
-                <artifactId>javax.inject</artifactId>
-                <version>1</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
                 <version>4.2.2</version>
@@ -313,7 +308,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>1.10.19</version>
+                <version>2.23.4</version>
             </dependency>
             <dependency>
                 <groupId>org.mock-server</groupId>


### PR DESCRIPTION
Mockito is now more strict about unnecessary mocks. Also javax.inject is
unmaintained and annotations can be obtained from Guice.

This commit contains changes from #273 authored by @TheIndifferent that
had become stale. Thank you!

Supersedes: #273.