### PR TITLE
Fix exception thrown when restarting ServiceHelper

### DIFF
--- a/apollo-test/src/test/java/com/spotify/apollo/test/helper/ServiceHelperTest.java
+++ b/apollo-test/src/test/java/com/spotify/apollo/test/helper/ServiceHelperTest.java
@@ -283,6 +283,17 @@ public class ServiceHelperTest {
     serviceHelper.start();
   }
 
+  @Test
+  public void shouldWorkAfterRestart() throws Exception {
+    when(someService.thatDoesThings()).thenReturn(TEST_THING);
+
+    serviceHelper.close();
+    serviceHelper.start();
+
+    String response = doGet();
+    assertThat(response, is(TEST_THING));
+  }
+
   private void resolveRegistry(Environment environment) {
     assertThat(environment.resolve(SemanticMetricRegistry.class), is(notNullValue()));
   }


### PR DESCRIPTION
The Maven Failsafe plugin supports rerunning failed tests (http://maven.apache.org/surefire/maven-failsafe-plugin/integration-test-mojo.html#rerunFailingTestsCount). A rerun causes the Failsafe plugin to restart all test rules. If you enable reruns for a test using a `ServiceHelper` as a test rule, the `ServiceHelper` will throw an `IllegalStateException` during the restart due to https://github.com/spotify/apollo/blob/1.x/apollo-test/src/main/java/com/spotify/apollo/test/ServiceHelper.java#L534. This happens because the `started` `CountDownLatch` is not reset during the shutdown. This PR fixes the issue by changing `started` to a `Semaphore` that is reset during shutdown.