### PR TITLE
Add JUnit 5 ServiceHelper extension

### DIFF
--- a/apollo-api-impl/pom.xml
+++ b/apollo-api-impl/pom.xml
@@ -86,8 +86,8 @@
 
         <!--test scope-->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apollo-api/pom.xml
+++ b/apollo-api/pom.xml
@@ -55,8 +55,8 @@
 
         <!-- test scope -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apollo-core/pom.xml
+++ b/apollo-core/pom.xml
@@ -46,8 +46,8 @@
             <artifactId>config</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apollo-entity/pom.xml
+++ b/apollo-entity/pom.xml
@@ -72,8 +72,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apollo-environment/pom.xml
+++ b/apollo-environment/pom.xml
@@ -65,8 +65,8 @@
 
         <!--test scope-->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apollo-extra/pom.xml
+++ b/apollo-extra/pom.xml
@@ -85,8 +85,8 @@
 
         <!--test scope-->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apollo-http-service/pom.xml
+++ b/apollo-http-service/pom.xml
@@ -53,8 +53,8 @@
 
         <!--test scope-->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apollo-http-service/pom.xml
+++ b/apollo-http-service/pom.xml
@@ -63,12 +63,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit</artifactId>
             <scope>test</scope>
         </dependency>

--- a/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/acceptance/AcceptanceIT.java
+++ b/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/acceptance/AcceptanceIT.java
@@ -19,12 +19,11 @@
  */
 package com.spotify.apollo.httpservice.acceptance;
 
+import io.cucumber.junit.Cucumber;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
 public class AcceptanceIT {

--- a/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/acceptance/RequestStepdefs.java
+++ b/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/acceptance/RequestStepdefs.java
@@ -19,20 +19,6 @@
  */
 package com.spotify.apollo.httpservice.acceptance;
 
-import com.spotify.apollo.Request;
-import com.spotify.apollo.Response;
-import com.spotify.apollo.Status;
-
-import java.io.File;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
-
-import cucumber.api.java.en.And;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
-import okio.ByteString;
-
 import static com.spotify.apollo.test.unit.StatusTypeMatchers.withCode;
 import static com.spotify.apollo.test.unit.StatusTypeMatchers.withReasonPhrase;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -43,6 +29,18 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
+import com.spotify.apollo.Request;
+import com.spotify.apollo.Response;
+import com.spotify.apollo.Status;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import java.io.File;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import okio.ByteString;
 
 public class RequestStepdefs {
 

--- a/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/acceptance/RunTestInFocus.java
+++ b/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/acceptance/RunTestInFocus.java
@@ -19,13 +19,12 @@
  */
 package com.spotify.apollo.httpservice.acceptance;
 
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import cucumber.api.CucumberOptions;
-import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(tags = {"@Focus"})

--- a/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/acceptance/ServiceStepdefs.java
+++ b/apollo-http-service/src/test/java/com/spotify/apollo/httpservice/acceptance/ServiceStepdefs.java
@@ -19,23 +19,19 @@
  */
 package com.spotify.apollo.httpservice.acceptance;
 
-import com.google.common.base.Splitter;
-
-import com.spotify.apollo.AppInit;
-import com.spotify.apollo.test.ServiceHelper;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Optional;
-
-import cucumber.api.java.After;
-import cucumber.api.java.en.And;
-import cucumber.api.java.en.Given;
-
 import static com.google.common.collect.Iterables.toArray;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import com.google.common.base.Splitter;
+import com.spotify.apollo.AppInit;
+import com.spotify.apollo.test.ServiceHelper;
+import io.cucumber.java.After;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ServiceStepdefs {
 

--- a/apollo-route/pom.xml
+++ b/apollo-route/pom.xml
@@ -45,8 +45,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apollo-test/pom.xml
+++ b/apollo-test/pom.xml
@@ -96,6 +96,10 @@
             <artifactId>hamcrest-library</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
         </dependency>
@@ -108,6 +112,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-testkit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/apollo-test/pom.xml
+++ b/apollo-test/pom.xml
@@ -96,8 +96,8 @@
             <artifactId>hamcrest-library</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/apollo-test/src/main/java/com/spotify/apollo/test/ServerHelperSetup.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/ServerHelperSetup.java
@@ -1,0 +1,45 @@
+/*
+ * -\-\-
+ * Spotify Apollo Testing Helpers
+ * --
+ * Copyright (C) 2013 - 2015 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.test;
+
+import com.spotify.apollo.module.ApolloModule;
+
+interface ServerHelperSetup<T extends ServerHelperSetup<T>> {
+
+  T domain(String domain);
+
+  T disableMetaApi();
+
+  T args(String... args);
+
+  T conf(String key, String value);
+
+  T conf(String key, Object value);
+
+  T resetConf(String key);
+
+  T forwardingNonStubbedRequests(boolean forward);
+
+  T startTimeoutSeconds(int timeoutSeconds);
+
+  T withModule(ApolloModule module);
+
+  T scheme(String scheme);
+}

--- a/apollo-test/src/main/java/com/spotify/apollo/test/ServiceHelperExtension.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/ServiceHelperExtension.java
@@ -1,0 +1,147 @@
+/*
+ * -\-\-
+ * Spotify Apollo Testing Helpers
+ * --
+ * Copyright (C) 2013 - 2015 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.test;
+
+import com.spotify.apollo.AppInit;
+import com.spotify.apollo.module.ApolloModule;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public final class ServiceHelperExtension
+    implements ServerHelperSetup<ServiceHelperExtension>,
+    BeforeEachCallback,
+    AfterEachCallback,
+    ParameterResolver {
+
+  private final ServiceHelper serviceHelper;
+
+  private ServiceHelperExtension() {
+    throw new UnsupportedOperationException(
+        getClass().getSimpleName() + " does not support declarative registration via @"
+            + ExtendWith.class.getSimpleName()
+            + ". Please declare this extension programmatically as a field using @"
+            + RegisterExtension.class.getSimpleName());
+  }
+
+  private ServiceHelperExtension(ServiceHelper serviceHelper) {
+    this.serviceHelper = serviceHelper;
+  }
+
+  public static ServiceHelperExtension create(AppInit appInit, String serviceName) {
+    return new ServiceHelperExtension(ServiceHelper.create(appInit, serviceName));
+  }
+
+  public static ServiceHelperExtension create(
+      AppInit appInit, String serviceName, StubClient stubClient) {
+    return new ServiceHelperExtension(ServiceHelper.create(appInit, serviceName, stubClient));
+  }
+
+  @Override
+  public ServiceHelperExtension domain(String domain) {
+    serviceHelper.domain(domain);
+    return this;
+  }
+
+  @Override
+  public ServiceHelperExtension disableMetaApi() {
+    serviceHelper.disableMetaApi();
+    return this;
+  }
+
+  @Override
+  public ServiceHelperExtension args(String... args) {
+    serviceHelper.args();
+    return this;
+  }
+
+  @Override
+  public ServiceHelperExtension conf(String key, String value) {
+    serviceHelper.conf(key, value);
+    return this;
+  }
+
+  @Override
+  public ServiceHelperExtension conf(String key, Object value) {
+    serviceHelper.conf(key, key);
+    return this;
+  }
+
+  @Override
+  public ServiceHelperExtension resetConf(String key) {
+    serviceHelper.resetConf(key);
+    return this;
+  }
+
+  @Override
+  public ServiceHelperExtension forwardingNonStubbedRequests(boolean forward) {
+    serviceHelper.forwardingNonStubbedRequests(forward);
+    return this;
+  }
+
+  @Override
+  public ServiceHelperExtension startTimeoutSeconds(int timeoutSeconds) {
+    serviceHelper.startTimeoutSeconds(timeoutSeconds);
+    return this;
+  }
+
+  @Override
+  public ServiceHelperExtension withModule(ApolloModule module) {
+    serviceHelper.withModule(module);
+    return this;
+  }
+
+  @Override
+  public ServiceHelperExtension scheme(String scheme) {
+    serviceHelper.scheme(scheme);
+    return this;
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) throws Exception {
+    serviceHelper.start();
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) throws Exception {
+    serviceHelper.close();
+  }
+
+  @Override
+  public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext context)
+      throws ParameterResolutionException {
+    return ServiceHelper.class.equals(parameterContext.getParameter().getType());
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext parameterContext, ExtensionContext context)
+      throws ParameterResolutionException {
+    return serviceHelper;
+  }
+
+  public ServiceHelper getServiceHelper() {
+    return serviceHelper;
+  }
+}

--- a/apollo-test/src/test/java/com/spotify/apollo/test/ServiceHelperCorrectUsage.java
+++ b/apollo-test/src/test/java/com/spotify/apollo/test/ServiceHelperCorrectUsage.java
@@ -1,0 +1,64 @@
+/*
+ * -\-\-
+ * Spotify Apollo Testing Helpers
+ * --
+ * Copyright (C) 2013 - 2015 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.spotify.apollo.Environment;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class ServiceHelperCorrectUsage {
+
+  @RegisterExtension
+  static final ServiceHelperExtension serviceHelperExtension =
+      ServiceHelperExtension.create(ServiceHelperCorrectUsage::appInit, "test-service");
+
+  private static final AtomicInteger appInitInvocationCount = new AtomicInteger();
+
+  @Test
+  void testWithAccessor() {
+    assertStarted(serviceHelperExtension.getServiceHelper());
+  }
+
+  @Test
+  void testWithParameter(ServiceHelper serviceHelper) {
+    assertStarted(serviceHelper);
+  }
+
+  static int getAppInitInvocationCount() {
+    return appInitInvocationCount.get();
+  }
+
+  static void resetAppInitInvocationCount() {
+    appInitInvocationCount.set(0);
+  }
+
+  private void assertStarted(ServiceHelper serviceHelper) {
+    assertNotNull(serviceHelper);
+    assertNotNull(serviceHelper.getInstance());
+  }
+
+  private static void appInit(Environment environment) {
+    assertNotNull(environment);
+    appInitInvocationCount.incrementAndGet();
+  }
+}

--- a/apollo-test/src/test/java/com/spotify/apollo/test/ServiceHelperExtensionTest.java
+++ b/apollo-test/src/test/java/com/spotify/apollo/test/ServiceHelperExtensionTest.java
@@ -1,0 +1,53 @@
+/*
+ * -\-\-
+ * Spotify Apollo Testing Helpers
+ * --
+ * Copyright (C) 2013 - 2015 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.test;
+
+import static org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor.ENGINE_ID;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+class ServiceHelperExtensionTest {
+
+  @AfterEach
+  void afterEach() {
+    ServiceHelperCorrectUsage.resetAppInitInvocationCount();
+  }
+
+  @Test
+  void shouldFailToInstantiateTestClassWhenExtensionDeclaredUsingExtendWith() {
+    EngineTestKit.engine(ENGINE_ID)
+        .selectors(selectClass(ServiceHelperIncorrectUsage.class))
+        .execute()
+        .containers()
+        .assertStatistics(stats -> stats.failed(1));
+  }
+
+  @Test
+  void shouldExecuteTestsWhenExtensionDeclaredProgrammatically() {
+    EngineTestKit.engine(ENGINE_ID)
+        .selectors(selectClass(ServiceHelperCorrectUsage.class))
+        .execute()
+        .tests()
+        .assertStatistics(stats -> stats.started(2).succeeded(2));
+  }
+}

--- a/apollo-test/src/test/java/com/spotify/apollo/test/ServiceHelperIncorrectUsage.java
+++ b/apollo-test/src/test/java/com/spotify/apollo/test/ServiceHelperIncorrectUsage.java
@@ -1,0 +1,33 @@
+/*
+ * -\-\-
+ * Spotify Apollo Testing Helpers
+ * --
+ * Copyright (C) 2013 - 2015 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+package com.spotify.apollo.test;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ServiceHelperExtension.class)
+class ServiceHelperIncorrectUsage {
+
+  @Test
+  void emptyTest() {}
+
+  @Test
+  void testWithParameter(ServiceHelper ignore) {}
+}

--- a/examples/brewery/pom.xml
+++ b/examples/brewery/pom.xml
@@ -41,9 +41,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/jetty-http-server/pom.xml
+++ b/modules/jetty-http-server/pom.xml
@@ -56,8 +56,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/metrics/pom.xml
+++ b/modules/metrics/pom.xml
@@ -109,8 +109,8 @@
 
         <!-- test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/okhttp-client/pom.xml
+++ b/modules/okhttp-client/pom.xml
@@ -64,8 +64,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     </scm>
 
     <properties>
-        <cucumber.version>1.2.5</cucumber.version>
+        <cucumber.version>4.8.0</cucumber.version>
         <auto-matter.version>0.15.3</auto-matter.version>
         <logback.version>1.2.3</logback.version>
         <jackson.version>2.10.0</jackson.version>
@@ -285,18 +285,13 @@
                 <version>${junit.version}</version>
             </dependency>
             <dependency>
-                <groupId>info.cukes</groupId>
+                <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-java</artifactId>
                 <version>${cucumber.version}</version>
             </dependency>
             <dependency>
-                <groupId>info.cukes</groupId>
+                <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-junit</artifactId>
-                <version>${cucumber.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>info.cukes</groupId>
-                <artifactId>cucumber-core</artifactId>
                 <version>${cucumber.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <netty.version>4.1.38.Final</netty.version>
         <jetty.version>9.4.19.v20190610</jetty.version>
         <junit.version>5.5.2</junit.version>
+        <junit.testkit.version>1.5.2</junit.testkit.version>
     </properties>
 
     <dependencyManagement>
@@ -283,6 +284,11 @@
                 <groupId>org.junit.vintage</groupId>
                 <artifactId>junit-vintage-engine</artifactId>
                 <version>${junit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-testkit</artifactId>
+                <version>${junit.testkit.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.cucumber</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <guava.version>28.1-jre</guava.version>
         <netty.version>4.1.38.Final</netty.version>
         <jetty.version>9.4.19.v20190610</jetty.version>
+        <junit.version>5.5.2</junit.version>
     </properties>
 
     <dependencyManagement>
@@ -274,9 +275,14 @@
 
             <!-- test dependencies -->
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>${junit.version}</version>
             </dependency>
             <dependency>
                 <groupId>info.cukes</groupId>


### PR DESCRIPTION
This PR is a combination of 3 commits:

#### Use JUnit 5 with vintage and jupiter engines

Migrate from JUnit 4 to JUnit 5 with a backward-compatible test engine. This allows writing both JUnit 4 and 5 tests. It also makes it possible to add a JUnit 5 ServiceHelper extension.

#### Bump cucumber version

Move from deprecated 1.2.5 to 4.8.0 primarily to get rid of deprecation warnings and be more JUnit 5 compatible.

#### Add JUnit 5 service helper extension

The added extension mirrors `ServiceHelper` rule API and allows to access the created helper via a getter or an injected method parameter.

Declarative registration of this extension is not allowed and throws an exception. This is because there is no good way to configure the extension and specify `AppInit` or `ServiceHelper` configuration.