### PR TITLE
Use favicon from the new CDN

### DIFF
--- a/website/source/_layouts/default.ejs
+++ b/website/source/_layouts/default.ejs
@@ -19,10 +19,10 @@
     <script type="text/javascript">try{Typekit.load({ async: true });}catch(e){}</script>
 
     <!--[if IE]>
-    <link rel="shortcut icon" href="//d2c87l0yth4zbw.global.ssl.fastly.net/i/_global/favicon.ico">
+    <link rel="shortcut icon" href="//www.scdn.co/i/_global/favicon.ico">
     <![endif]-->
 
-    <link rel="icon" href="//d2c87l0yth4zbw.global.ssl.fastly.net/i/_global/favicon.png">
+    <link rel="icon" href="//www.scdn.co/i/_global/favicon.png">
     <link rel="stylesheet" href="all.css">
   </head>
 


### PR DESCRIPTION
This fix is for the website https://spotify.github.io/apollo/.

After merging, someone will have to deploy it manually using instructions in https://github.com/spotify/apollo/blob/master/website/README.md.