### PR TITLE
Add ERROR_RATIO_4XX to default set of metrics

### DIFF
--- a/modules/metrics/README.md
+++ b/modules/metrics/README.md
@@ -135,7 +135,7 @@ easily configurable from the apollo service configuration.
 
 key | type | required | note
 --- | ---- | -------- | ----
-`metrics.server` | string list | optional | list of [`What`](src/main/java/com/spotify/apollo/metrics/semantic/What.java) names to enable; defaults to [ENDPOINT_REQUEST_RATE, ENDPOINT_REQUEST_DURATION, DROPPED_REQUEST_RATE, ERROR_RATIO]
+`metrics.server` | string list | optional | list of [`What`](src/main/java/com/spotify/apollo/metrics/semantic/What.java) names to enable; defaults to [ENDPOINT_REQUEST_RATE, ENDPOINT_REQUEST_DURATION, ENDPOINT_REQUEST_DURATION_THRESHOLD_RATE, DROPPED_REQUEST_RATE, ERROR_RATIO, ERROR_RATIO_4XX, ERROR_RATIO_5XX]
 `metrics.precreate-codes` | int list | optional | list of status codes to precreate request-rate meters for, default empty
 `metrics.reservoir-ttl` | int | optional | When to purge old values from the histogram, defaults to 300 seconds. Note, setting this to a large value will increase the amount of memory used to keep track samples.
 `ffwd.type` | string | optional | indicates which type of ffwd reporter to use. Available types are `agent` and `http`. see below for details. default is `agent`.

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/MetricsConfig.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/semantic/MetricsConfig.java
@@ -25,6 +25,7 @@ import static com.spotify.apollo.metrics.semantic.What.ENDPOINT_REQUEST_DURATION
 import static com.spotify.apollo.metrics.semantic.What.ENDPOINT_REQUEST_DURATION_THRESHOLD_RATE;
 import static com.spotify.apollo.metrics.semantic.What.ENDPOINT_REQUEST_RATE;
 import static com.spotify.apollo.metrics.semantic.What.ERROR_RATIO;
+import static com.spotify.apollo.metrics.semantic.What.ERROR_RATIO_4XX;
 import static com.spotify.apollo.metrics.semantic.What.ERROR_RATIO_5XX;
 
 import com.google.inject.Inject;
@@ -47,6 +48,7 @@ public class MetricsConfig {
           ENDPOINT_REQUEST_DURATION_THRESHOLD_RATE,
           DROPPED_REQUEST_RATE,
           ERROR_RATIO,
+          ERROR_RATIO_4XX,
           ERROR_RATIO_5XX);
 
   static final int DEFAULT_TTL_SECONDS = (int) TimeUnit.MINUTES.toSeconds(5);


### PR DESCRIPTION
Emit ERROR_RATIO_4XX metric by default and update documentation.