### PR TITLE
Remove service-framework-version tag from metrics

### DIFF
--- a/apollo-http-service/src/main/java/com/spotify/apollo/httpservice/MetricIdModule.java
+++ b/apollo-http-service/src/main/java/com/spotify/apollo/httpservice/MetricIdModule.java
@@ -49,7 +49,6 @@ class MetricIdModule extends AbstractApolloModule {
   public MetricId metricId(MetaDescriptor metaDescriptor) {
     return MetricId.build("apollo").tagged(
         "service-framework", "http-service",
-        "service-framework-version", metaDescriptor.apolloVersion(),
         "application", metaDescriptor.descriptor().serviceName());
   }
 


### PR DESCRIPTION
This tag changes with every new release of Apollo. Due to limitations with an internal systems we would like the metric tags to stay the same when upgrading to a new version of Apollo.