### PR TITLE
upgrade okio to 2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
             <dependency>
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio</artifactId>
-                <version>1.17.4</version>
+                <version>2.7.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>


### PR DESCRIPTION
A number of internal Spotify libraries related to distributed tracing are introducing a requirement on okio 2.x and okhttp3 4.x.

Between 1.x and 2.x, okio was rewritten from Java to Kotlin, and promises to be API compatible with 1.x:

> Okio 2 is a major release that upgrades the library’s implementation language from Java to Kotlin.

> Okio 2.x is binary-compatible with Okio 1.x and does not change any behavior. Classes and .jar files compiled against 1.x can be used with 2.x without recompiling.

> Okio 2.x is .java source compatible with Okio 1.x in all but one corner case. In Okio 1.x Buffer would throw an unchecked IllegalStateException when attempting to read more bytes than available. Okio 2.x now throws a checked EOFException in this case. This is now consistent with the behavior of its BufferedSource interface. Java callers that don’t already catch IOException will now need to.

https://square.github.io/okio/changelog/#version-200-rc1

Since Apollo uses okio, this upgrades Apollo to the 2.x line of okio as a way to verify that there are no problems within Apollo before we start to upgrade Apollo-using services.