### PR TITLE
Making hasPayload more generic

### DIFF
--- a/apollo-test/src/main/java/com/spotify/apollo/test/unit/ResponseMatchers.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/unit/ResponseMatchers.java
@@ -133,7 +133,7 @@ public final class ResponseMatchers {
    * @param payloadMatcher {@link Matcher} for the payload.
    * @return A matcher
    */
-  public static <T> Matcher<Response<T>> hasPayload(Matcher<? super T> payloadMatcher) {
+  public static <T> Matcher<Response<? super T>> hasPayload(Matcher<? super T> payloadMatcher) {
     return new TypeSafeMatcher<Response<T>>() {
       @Override
       protected boolean matchesSafely(Response<T> item) {

--- a/apollo-test/src/main/java/com/spotify/apollo/test/unit/ResponseMatchers.java
+++ b/apollo-test/src/main/java/com/spotify/apollo/test/unit/ResponseMatchers.java
@@ -134,9 +134,9 @@ public final class ResponseMatchers {
    * @return A matcher
    */
   public static <T> Matcher<Response<? super T>> hasPayload(Matcher<? super T> payloadMatcher) {
-    return new TypeSafeMatcher<Response<T>>() {
+    return new TypeSafeMatcher<Response<? super T>>() {
       @Override
-      protected boolean matchesSafely(Response<T> item) {
+      protected boolean matchesSafely(Response<? super T> item) {
         return item.payload()
             .map(payloadMatcher::matches)
             .orElse(false);
@@ -149,8 +149,8 @@ public final class ResponseMatchers {
       }
 
       @Override
-      protected void describeMismatchSafely(Response<T> item, Description mismatchDescription) {
-        final Optional<T> payload = item.payload();
+      protected void describeMismatchSafely(Response<? super T> item, Description mismatchDescription) {
+        final Optional<? super T> payload = item.payload();
         if (!payload.isPresent()) {
           mismatchDescription.appendText("there is no payload");
         } else {


### PR DESCRIPTION
If used with `Matchers.allOf` this is needed for the typing to work.

Example that's broken (that will work with this fix):

    assertThat(
        unitUnderTest.functionThatReturnsCompletionStageOfResponseOfString(),
        stageWillCompleteWithValueThat(
            allOf(
                hasHeader("Content-Type", is("application/json")),
                hasStatus(withCode(Status.OK)),
                hasPayload(is("the-returned-payload")))
        )
    );

What you have to do now:

    assertThat(
        unitUnderTest.functionThatReturnsCompletionStageOfResponseOfString(),
        stageWillCompleteWithValueThat(
            allOf(
                hasHeader("Content-Type", is("application/json")),
                hasStatus(withCode(Status.OK)),
                hasPayload(is((Object) "the-returned-payload")))
        )
    );
