### PR TITLE
[metrics] Add flush option to ffwd reporters

### DIFF
--- a/modules/metrics/README.md
+++ b/modules/metrics/README.md
@@ -157,6 +157,7 @@ will then emit a '0' value until the first time a certain status code shows up.
 key | type | required | note
 --- | ---- | -------- | ----
 `ffwd.interval` | int | optional | interval in seconds of reporting metrics to ffwd; default 30
+`ffwd.flush` | boolean | optional | include a final flush of metrics on service shut down; default `False`
 `ffwd.host` | string | optional | host where the ffwd agent is running. default `localhost`
 `ffwd.port` | int | optional | port where the ffwd agent is running. default `19091`
 
@@ -174,6 +175,7 @@ ffwd.port = 19091
 key | type | required | note
 --- | ---- | -------- | ----
 `ffwd.interval` | int | optional | interval in seconds of reporting metrics to ffwd; default 30
+`ffwd.flush` | boolean | optional | include a final flush of metrics on service shut down; default `False`
 `ffwd.discovery.type` | string | required | indicates how to discovery http endpoints. Available options are `static` and `srv`. See below for details.
 
 #### Example

--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/FfwdConfig.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/FfwdConfig.java
@@ -19,6 +19,7 @@
  */
 package com.spotify.apollo.metrics;
 
+import static com.spotify.apollo.environment.ConfigUtil.optionalBoolean;
 import static com.spotify.apollo.environment.ConfigUtil.optionalInt;
 import static com.spotify.apollo.environment.ConfigUtil.optionalString;
 
@@ -51,15 +52,16 @@ interface FfwdConfig {
     final String type = optionalString(config, "type").orElse("agent");
 
     final int interval = optionalInt(config, "interval").orElse(DEFAULT_INTERVAL);
+    final boolean flush = optionalBoolean(config, "flush").orElse(Boolean.TRUE);
 
     switch (type) {
       case "agent":
         final Optional<String> host = optionalString(config, "host");
         final Optional<Integer> port = optionalInt(config, "port");
-        return new Agent(interval, host, port);
+        return new Agent(interval, flush, host, port);
       case "http":
         final DiscoveryConfig discovery = DiscoveryConfig.fromConfig(config.getConfig("discovery"));
-        return new Http(interval, discovery);
+        return new Http(interval, flush, discovery);
       default:
         throw new RuntimeException("Unrecognized ffwd type: " + type);
     }
@@ -67,17 +69,24 @@ interface FfwdConfig {
 
   class Agent implements FfwdConfig {
     private final int interval;
+    private final boolean flush;
     private final Optional<String> host;
     private final Optional<Integer> port;
 
-    Agent(final int interval, final Optional<String> host, final Optional<Integer> port) {
+    Agent(final int interval, final boolean flush, final Optional<String> host,
+     final Optional<Integer> port) {
       this.interval = interval;
+      this.flush = flush;
       this.host = host;
       this.port = port;
     }
 
     int getInterval() {
       return interval;
+    }
+
+    boolean getFlush() {
+      return flush;
     }
 
     Optional<String> getHost() {
@@ -105,22 +114,28 @@ interface FfwdConfig {
       return () -> {
         final FastForwardReporter reporter = builder.build();
         reporter.start();
-        return reporter::stop;
+        return flush ? reporter::stopWithFlush : reporter::stop;
       };
     }
   }
 
   class Http implements FfwdConfig {
     private final int interval;
+    private final boolean flush;
     private final DiscoveryConfig discovery;
 
-    Http(final int interval, final DiscoveryConfig discovery) {
+    Http(final int interval, final boolean flush, final DiscoveryConfig discovery) {
       this.interval = interval;
+      this.flush = flush;
       this.discovery = discovery;
     }
 
     int getInterval() {
       return interval;
+    }
+
+    boolean getFlush() {
+      return flush;
     }
 
     DiscoveryConfig getDiscovery() {
@@ -145,7 +160,7 @@ interface FfwdConfig {
       return () -> {
         final FastForwardHttpReporter reporter = builder.build();
         reporter.start();
-        return reporter::stop;
+        return flush ? reporter::stopWithFlush : reporter::stop;
       };
     }
   }

--- a/modules/metrics/src/test/java/com/spotify/apollo/metrics/ConfigTest.java
+++ b/modules/metrics/src/test/java/com/spotify/apollo/metrics/ConfigTest.java
@@ -43,8 +43,18 @@ public class ConfigTest {
 
       assertEquals(Optional.empty(), ffwdCompletelyEmpty.getHost());
       assertEquals(Optional.empty(), ffwdCompletelyEmpty.getPort());
+      assertEquals(Boolean.TRUE, ffwdCompletelyEmpty.getFlush());
       assertEquals(30, ffwdCompletelyEmpty.getInterval());
       assertEquals(30, ffwdEmpty.getInterval());
+    }
+
+    @Test
+    public void agentConfigNoFlush() {
+      String ffwdjson = "{\"ffwd\":{\"flush\":\"false\"}}";
+      FfwdConfig.Agent ffwdFlush = (FfwdConfig.Agent) FfwdConfig.fromConfig(conf(ffwdjson));
+
+      assertEquals(30, ffwdFlush.getInterval());
+      assertEquals(Boolean.FALSE, ffwdFlush.getFlush());
     }
 
     @Test
@@ -58,6 +68,22 @@ public class ConfigTest {
       final FfwdConfig.Http http = (FfwdConfig.Http) config;
 
       assertEquals(30, http.getInterval());
+      assertEquals(Boolean.TRUE, http.getFlush());
+    }
+
+    @Test
+    public void httpConfigWithFlush() {
+      String json =
+          "{\"ffwd\":{\"type\":\"http\",\"flush\":\"false\",\"discovery\":{\"type\":\"srv\","
+          + "\"record\":\"hello\"}}}";
+      FfwdConfig config = FfwdConfig.fromConfig(conf(json));
+
+      assertEquals(FfwdConfig.Http.class, config.getClass());
+
+      final FfwdConfig.Http http = (FfwdConfig.Http) config;
+
+      assertEquals(30, http.getInterval());
+      assertEquals(Boolean.FALSE, http.getFlush());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <auto-value.version>1.7.4</auto-value.version>
         <logback.version>1.2.3</logback.version>
         <jackson.version>2.11.2</jackson.version>
-        <semantic-metrics.version>1.0.2</semantic-metrics.version>
+        <semantic-metrics.version>1.1.6</semantic-metrics.version>
         <guava.version>29.0-jre</guava.version>
         <netty.version>4.1.45.Final</netty.version>
         <junit.testkit.version>1.5.2</junit.testkit.version>
@@ -580,6 +580,7 @@
                         <artifactId>missinglink-maven-plugin</artifactId>
                         <version>0.2.0</version>
                         <configuration>
+                            <includeScopes>compile,test,runtime</includeScopes>
                             <failOnConflicts>true</failOnConflicts>
                             <ignoreDestinationPackages>
                                 <!-- not always present for all modules, will be present in final artifact -->
@@ -601,6 +602,10 @@
                                 <!-- netty references this for < Java 7 JDKs -->
                                 <ignoreDestinationPackage>
                                     <package>com.jcraft.jzlib</package>
+                                </ignoreDestinationPackage>
+                                <!-- ignore references to Android util in okhttp3 -->
+                                <ignoreDestinationPackage>
+                                    <package>android.util</package>
                                 </ignoreDestinationPackage>
                             </ignoreDestinationPackages>
                             <ignoreSourcePackages>


### PR DESCRIPTION
We received a report that: 

"In a high throughput pubsub subscriber/publisher, every deploy looks like it is losing a lot of messages during shutdown on exit.
If you prematurely shut down the publisher before the subscriber, a lot of messages get dropped (with failure reported), but they never showed up in the metrics.
Should calling FastForward(Http)Reporter.stop() be enough to flush the data? Do you think the problem would be that Apollo doesn’t do that, or that the stop method itself doesn’t flush?
Neither apollo nor ffwd was doing a final flush of these metrics. 
The ffwd reporters are responsible for flushing the metrics. It's running on a 30 second interval between flushes
during shutdown, the ffwd reporter is simply stopped (thread responsible for flushing is shutdown immediately)."
 
This PR allows you to configure both the FastForwardHttpReporter and FastForwardReporter to do a final flush of metrics on shutdown using the `ffwd.flush` flag in your config. This should help remediate the loss of metrics in cases like what I described above. 

I ran into a few issues when upgrading the libraries for this PR, leading me to make some additions to the parent pom to get this to pass for java 8. The `missinglink` profile was complaining about pretty much every dependency related to the Netflix load balancer used in ffwd-http-reporter. This was remediated by changing the scopes: `<includeScopes>compile,test,runtime</includeScopes>`. Is the `missinglink` profile still something the owners care about? It seems a bit outdated and looks like it only gets called for java8. 
