### PR TITLE
Upgrade semantic metrics to 1.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <auto-value.version>1.7.4</auto-value.version>
         <logback.version>1.2.3</logback.version>
         <jackson.version>2.11.2</jackson.version>
-        <semantic-metrics.version>1.1.6</semantic-metrics.version>
+        <semantic-metrics.version>1.1.7</semantic-metrics.version>
         <guava.version>29.0-jre</guava.version>
         <netty.version>4.1.45.Final</netty.version>
         <junit.testkit.version>1.5.2</junit.testkit.version>


### PR DESCRIPTION
Latest release: https://github.com/spotify/semantic-metrics/releases/tag/1.1.7

**Note**: This is a breaking change if you were querying for sprawling keys (ex: apollo.apollo.apollo.apollo). You may have to update your queries to use the non-sprawling key. If you are not using a key in your query, the results should stay the same.

Would be good to add that note to the release notes for apollo as well :)