### PR TITLE
change auto-matter dependency scope to provided

### DIFF
--- a/apollo-api-impl/pom.xml
+++ b/apollo-api-impl/pom.xml
@@ -69,6 +69,7 @@
         <dependency>
             <groupId>io.norberg</groupId>
             <artifactId>auto-matter</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.norberg</groupId>


### PR DESCRIPTION
I noticed in a project that depends on `apollo-api-impl` that
auto-matter and its transitive dependencies (like javapoet) were being
pulled into the project as compile-scope dependencies.