### PR TITLE
Remove io.netty dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
         <jackson.version>2.11.2</jackson.version>
         <semantic-metrics.version>1.1.7</semantic-metrics.version>
         <guava.version>29.0-jre</guava.version>
-        <netty.version>4.1.45.Final</netty.version>
         <junit.testkit.version>1.5.2</junit.testkit.version>
         <slf4j.version>1.7.30</slf4j.version>
         <hamcrest.version>2.2</hamcrest.version>
@@ -63,19 +62,7 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>${netty.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
 
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
             <dependency>
                 <groupId>com.squareup.okhttp</groupId>
                 <artifactId>okhttp</artifactId>


### PR DESCRIPTION
Added in https://github.com/spotify/apollo/pull/279, the only thing that uses netty is the mockserver which is used in the test scope.