### PR TITLE
Update junit dependencies.

### DIFF
--- a/apollo-test/src/test/java/com/spotify/apollo/test/ServiceHelperExtensionUsageTest.java
+++ b/apollo-test/src/test/java/com/spotify/apollo/test/ServiceHelperExtensionUsageTest.java
@@ -38,7 +38,7 @@ class ServiceHelperExtensionUsageTest {
     EngineTestKit.engine(ENGINE_ID)
         .selectors(selectClass(ServiceHelperIncorrectUsage.class))
         .execute()
-        .containers()
+        .containerEvents()
         .assertStatistics(stats -> stats.failed(1));
   }
 
@@ -47,7 +47,7 @@ class ServiceHelperExtensionUsageTest {
     EngineTestKit.engine(ENGINE_ID)
         .selectors(selectClass(ServiceHelperCorrectUsage.class))
         .execute()
-        .tests()
+        .testEvents()
         .assertStatistics(stats -> stats.started(2).succeeded(2));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -45,10 +45,10 @@
         <auto-matter.version>0.15.3</auto-matter.version>
         <auto-value.version>1.7.4</auto-value.version>
         <logback.version>1.2.3</logback.version>
-        <jackson.version>2.11.2</jackson.version>
+        <jackson.version>2.12.3</jackson.version>
         <semantic-metrics.version>1.1.7</semantic-metrics.version>
         <guava.version>29.0-jre</guava.version>
-        <junit.testkit.version>1.5.2</junit.testkit.version>
+        <junit.testkit.version>1.7.1</junit.testkit.version>
         <slf4j.version>1.7.30</slf4j.version>
         <hamcrest.version>2.2</hamcrest.version>
     </properties>
@@ -249,7 +249,7 @@
             <dependency>
               <groupId>org.junit</groupId>
               <artifactId>junit-bom</artifactId>
-              <version>5.5.2</version>
+              <version>5.7.1</version>
               <scope>import</scope>
               <type>pom</type>
             </dependency>


### PR DESCRIPTION
As a result of this PR junit:junit:4.12 (managed) =>  junit:junit:4.13.1 (managed).
This PR is triggered by an error in our test suite.
```
Caused by: org.junit.platform.commons.JUnitException: Failed to parse version of junit:junit: 4.13.1
```
[The same as](https://github.com/junit-team/junit5/issues/2529).
And the recommedation is to update `junit-vintage-engine`to version >= `5.7.0`.
`jackson.version` is updated mainly due to the fact that it brings [`junit:junit:4.12 (managed)`](https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom/2.11.2) version with it.

Might be a replacement for #323.