### PR TITLE
Make a HEAD /foo requests emit metrics for HEAD:/foo, not GET:/foo

### DIFF
--- a/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsCollectingEndpointRunnableFactoryDecorator.java
+++ b/modules/metrics/src/main/java/com/spotify/apollo/metrics/MetricsCollectingEndpointRunnableFactoryDecorator.java
@@ -42,20 +42,13 @@ class MetricsCollectingEndpointRunnableFactoryDecorator implements EndpointRunna
   @Override
   public EndpointRunnableFactory apply(EndpointRunnableFactory delegate) {
     return (request, requestContext, endpoint) -> {
-      final String endpointName;
-      // Normally request.request().method() and endpoint.info().getRequestMethod() are equal
-      // but since apollo lets GET endpoints also serve HEAD requests, they are different
-      // when the request is a HEAD request. The hack below makes sure we distinguish metrics
-      // for GET and HEAD requests.
-      // We could always take the else branch but I'm guessing that the comparison
-      // is cheaper than a needless concatenation.
-      if (request.request().method().equals(endpoint.info().getRequestMethod())) {
-        endpointName = endpoint.info().getName();
-      } else {
+      // Since endpoint.info().getName() is inaccurate for endpoints that accept multiple
+      // methods we use request.request().method() + ":" + endpoint.info().getUri()
+      // instead. The call to getName() performs a similar concatenation so this doesn't
+      // lead to extra creation of String objects.
         // but because GET endpoints serve HEAD requests info().getName() is
         // wrong does not distinguish HEAD and GET requests
-        endpointName = request.request().method() + ":" + endpoint.info().getUri();
-      }
+      final String endpointName = request.request().method() + ":" + endpoint.info().getUri();
 
       // note: will not time duration of matching and dispatching
       final RequestMetrics requestStats = metrics.metricsForEndpointCall(endpointName);

--- a/modules/metrics/src/test/java/com/spotify/apollo/metrics/MetricsCollectingEndpointRunnableFactoryDecoratorTest.java
+++ b/modules/metrics/src/test/java/com/spotify/apollo/metrics/MetricsCollectingEndpointRunnableFactoryDecoratorTest.java
@@ -88,7 +88,6 @@ public class MetricsCollectingEndpointRunnableFactoryDecoratorTest {
     when(ongoingRequest.request()).thenReturn(request);
     when(endpoint.info()).thenReturn(info);
     when(info.getUri()).thenReturn("/foo");
-    when(info.getRequestMethod()).thenReturn("GET");
     when(info.getName()).thenReturn("GET:/foo");
 
     when(delegate.create(ongoingRequestCaptor.capture(), requestContextCaptor.capture(), any()))


### PR DESCRIPTION
This fixes an issue that probably originates from the fact that
apollo registers a HEAD endpoint automatically for GET endpoints.
This means a HEAD request is served by a GET handler and endpoint
metrics are incorrectly reported for endpoint = GET:/foo rather than
HEAD:/foo.

