### PR TITLE
Revert "change auto-matter dependency scope to provided"

### DIFF
--- a/apollo-api-impl/pom.xml
+++ b/apollo-api-impl/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
             <groupId>io.norberg</groupId>
             <artifactId>auto-matter</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.norberg</groupId>


### PR DESCRIPTION
Reverts spotify/apollo#331

We found that quite a lot of repos internally were referring to `io.norberg.automatter` classes without having a declared dependency in their own pom.xml, causing their builds to break with this change in Apollo. The actual change here was not of high value so it makes more sense to revert this than attempt to address this in every internal repo with incomplete dependency declarations