### PR TITLE
Revert semantic-metrics to 1.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <version>1.17.12-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <description>Java libraries for writing composable microservices</fdescription>
+    <description>Java libraries for writing composable microservices</description>
 
     <modules>
         <module>apollo-bom</module>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <version>1.17.12-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <description>Java libraries for writing composable microservices</description>
+    <description>Java libraries for writing composable microservices</fdescription>
 
     <modules>
         <module>apollo-bom</module>
@@ -46,7 +46,7 @@
         <auto-value.version>1.7.4</auto-value.version>
         <logback.version>1.2.3</logback.version>
         <jackson.version>2.12.3</jackson.version>
-        <semantic-metrics.version>1.1.7</semantic-metrics.version>
+        <semantic-metrics.version>1.1.1</semantic-metrics.version>
         <guava.version>29.0-jre</guava.version>
         <junit.testkit.version>1.7.1</junit.testkit.version>
         <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
Reverts #330, which causes problems in downstream dependencies because of the removal of all shaded libraries in ffwd-http-client
Will update to new version of semantic-metrics once #342 has been merged