### PR TITLE
[metrics] Use semantic-metrics 1.1.1, revert flush function

### DIFF
--- a/modules/metrics/README.md
+++ b/modules/metrics/README.md
@@ -157,7 +157,6 @@ will then emit a '0' value until the first time a certain status code shows up.
 key | type | required | note
 --- | ---- | -------- | ----
 `ffwd.interval` | int | optional | interval in seconds of reporting metrics to ffwd; default 30
-`ffwd.flush` | boolean | optional | include a final flush of metrics on service shut down; default `False`
 `ffwd.host` | string | optional | host where the ffwd agent is running. default `localhost`
 `ffwd.port` | int | optional | port where the ffwd agent is running. default `19091`
 
@@ -175,7 +174,6 @@ ffwd.port = 19091
 key | type | required | note
 --- | ---- | -------- | ----
 `ffwd.interval` | int | optional | interval in seconds of reporting metrics to ffwd; default 30
-`ffwd.flush` | boolean | optional | include a final flush of metrics on service shut down; default `False`
 `ffwd.discovery.type` | string | required | indicates how to discovery http endpoints. Available options are `static` and `srv`. See below for details.
 
 #### Example

--- a/modules/metrics/src/test/java/com/spotify/apollo/metrics/ConfigTest.java
+++ b/modules/metrics/src/test/java/com/spotify/apollo/metrics/ConfigTest.java
@@ -43,18 +43,8 @@ public class ConfigTest {
 
       assertEquals(Optional.empty(), ffwdCompletelyEmpty.getHost());
       assertEquals(Optional.empty(), ffwdCompletelyEmpty.getPort());
-      assertEquals(Boolean.TRUE, ffwdCompletelyEmpty.getFlush());
       assertEquals(30, ffwdCompletelyEmpty.getInterval());
       assertEquals(30, ffwdEmpty.getInterval());
-    }
-
-    @Test
-    public void agentConfigNoFlush() {
-      String ffwdjson = "{\"ffwd\":{\"flush\":\"false\"}}";
-      FfwdConfig.Agent ffwdFlush = (FfwdConfig.Agent) FfwdConfig.fromConfig(conf(ffwdjson));
-
-      assertEquals(30, ffwdFlush.getInterval());
-      assertEquals(Boolean.FALSE, ffwdFlush.getFlush());
     }
 
     @Test
@@ -68,22 +58,6 @@ public class ConfigTest {
       final FfwdConfig.Http http = (FfwdConfig.Http) config;
 
       assertEquals(30, http.getInterval());
-      assertEquals(Boolean.TRUE, http.getFlush());
-    }
-
-    @Test
-    public void httpConfigWithFlush() {
-      String json =
-          "{\"ffwd\":{\"type\":\"http\",\"flush\":\"false\",\"discovery\":{\"type\":\"srv\","
-          + "\"record\":\"hello\"}}}";
-      FfwdConfig config = FfwdConfig.fromConfig(conf(json));
-
-      assertEquals(FfwdConfig.Http.class, config.getClass());
-
-      final FfwdConfig.Http http = (FfwdConfig.Http) config;
-
-      assertEquals(30, http.getInterval());
-      assertEquals(Boolean.FALSE, http.getFlush());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <auto-value.version>1.7.4</auto-value.version>
         <logback.version>1.2.3</logback.version>
         <jackson.version>2.12.3</jackson.version>
-        <semantic-metrics.version>1.1.7</semantic-metrics.version>
+        <semantic-metrics.version>1.1.1</semantic-metrics.version>
         <guava.version>29.0-jre</guava.version>
         <junit.testkit.version>1.7.1</junit.testkit.version>
         <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
Reverts #326 due to problems with downstream libraries using the shades packages in ffwd-http-client 0.4.0.
Using version 1.1.1 which seems to be the last version to include ffwd-http-client 0.4.0.

Will include newer version and reenable the flushing once we have moved downstreams deps away from importing the shaded packages