### PR TITLE
Set junit version to 4.13.2 to fix broken coverage

### DIFF
--- a/apollo-test/pom.xml
+++ b/apollo-test/pom.xml
@@ -100,6 +100,11 @@
             <artifactId>junit-vintage-engine</artifactId>
         </dependency>
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,12 @@
 
             <!-- test dependencies -->
             <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
               <groupId>org.junit</groupId>
               <artifactId>junit-bom</artifactId>
               <version>5.7.1</version>


### PR DESCRIPTION
Fix problem with jacoco coverage in apollo-core, introduced in #336.

Had to bump to junit 4.13.2, see https://github.com/junit-team/junit4/issues/1652.