### PR TITLE
Bump commons-io to 2.8.0 and guava 30.1.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <logback.version>1.2.3</logback.version>
         <jackson.version>2.12.3</jackson.version>
         <semantic-metrics.version>1.1.8</semantic-metrics.version>
-        <guava.version>29.0-jre</guava.version>
+        <guava.version>30.1.1-jre</guava.version>
         <junit.testkit.version>1.7.1</junit.testkit.version>
         <slf4j.version>1.7.30</slf4j.version>
         <hamcrest.version>2.2</hamcrest.version>
@@ -179,7 +179,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.6</version>
+                <version>2.8.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Replaces #346 and solves the dependabot issues