### PR TITLE
Upgrade guice 4.2.2 -> 5.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,10 @@
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>
-                <artifactId>guice</artifactId>
+                <artifactId>guice-bom</artifactId>
                 <version>5.0.1</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>net.sf.jopt-simple</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
                 <plugin>
                     <groupId>com.spotify</groupId>
                     <artifactId>missinglink-maven-plugin</artifactId>
-                    <version>0.2.0</version>
+                    <version>0.2.2</version>
                     <configuration>
                         <failOnConflicts>true</failOnConflicts>
                     </configuration>
@@ -466,7 +466,7 @@
                             <dependency>:auto-value-annotations::</dependency>
                             <dependency>javax.annotation:javax.annotation-api::</dependency>
                             <dependency>com.google.code.findbugs:::</dependency>
-                        </ignoredUnusedDeclaredDependencies>                    
+                        </ignoredUnusedDeclaredDependencies>
                     </configuration>
                 </execution>
                 </executions>
@@ -575,7 +575,7 @@
                     <plugin>
                         <groupId>com.spotify</groupId>
                         <artifactId>missinglink-maven-plugin</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.2.2</version>
                         <configuration>
                             <includeScopes>compile,test,runtime</includeScopes>
                             <failOnConflicts>true</failOnConflicts>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,18 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <!--
+              From Guice 5+ multi-bindings is officially part of the its core library.
+              From Guice 4.2.x Guice already transferred the code into its core library,
+              but left the artifact `guice-multibindings` with no code in it for backward compatibility.
+              We are explicitly settings this version here so that we can move our users to Guice 5.0.1
+              without breaking their projects.
+              We should delete this dependency as soon as we can guarantee everyone moved to 5.0.1 -->
+            <dependency>
+                <groupId>com.google.inject.extensions</groupId>
+                <artifactId>guice-multibindings</artifactId>
+                <version>4.2.3</version>
+            </dependency>
             <dependency>
                 <groupId>net.sf.jopt-simple</groupId>
                 <artifactId>jopt-simple</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,12 +76,7 @@
             <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
-                <version>4.2.2</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.inject.extensions</groupId>
-                <artifactId>guice-multibindings</artifactId>
-                <version>4.2.2</version>
+                <version>5.0.1</version>
             </dependency>
             <dependency>
                 <groupId>net.sf.jopt-simple</groupId>
@@ -97,28 +92,6 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.code.findbugs</groupId>
-                        <artifactId>jsr305</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.checkerframework</groupId>
-                        <artifactId>checker-qual</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.google.errorprone</groupId>
-                        <artifactId>error_prone_annotations</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.google.j2objc</groupId>
-                        <artifactId>j2objc-annotations</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>animal-sniffer-annotations</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -577,7 +577,6 @@
                     <plugin>
                         <groupId>com.spotify</groupId>
                         <artifactId>missinglink-maven-plugin</artifactId>
-                        <version>0.2.2</version>
                         <configuration>
                             <includeScopes>compile,test,runtime</includeScopes>
                             <failOnConflicts>true</failOnConflicts>

--- a/pom.xml
+++ b/pom.xml
@@ -125,13 +125,13 @@
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
-                <artifactId>metrics-core</artifactId>
-                <version>4.0.5</version>
+                <artifactId>metrics-jvm</artifactId>
+                <version>4.2.0</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
-                <artifactId>metrics-jvm</artifactId>
-                <version>4.0.5</version>
+                <artifactId>metrics-core</artifactId>
+                <version>4.2.0</version>
             </dependency>
             <dependency>
                 <groupId>com.spotify.metrics</groupId>


### PR DESCRIPTION
Upgrades Guice from 4.2.2 to 5.0.1.

# Why?

User @backuitist asked at issue https://github.com/spotify/apollo/issues/350 to do this change to remove a warning. We realized after investigation that guice 4.2.2 is not compatible with Java 16+, which will require us to do this upgrade to 5.0.1 anyway.

# Breaking changes

From documentation from their [release notes](https://github.com/google/guice/wiki/Guice501) and local tests, there's no breaking changes that we could perceive in Apollo code and its modules besides changes in dependencies.

This upgrade anyway poses a breaking change risk for users using Guice, which will be obligated to also upgrade their versions to match. Our rollout strategy has not been yet determined for this change.

## UPDATE

After testing with different projects, there's no change in the API of how Apollo is exposed, neither we could find a significant change in how Guice is used. This means that there's no breaking change perceived in both API and behaviour. With that in mind, I think we can go ahead and release this change to our users as a minor version upgrade