### PR TITLE
Unbom guice import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,8 @@
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>
-                <artifactId>guice-bom</artifactId>
+                <artifactId>guice</artifactId>
                 <version>5.0.1</version>
-                <scope>import</scope>
-                <type>pom</type>
             </dependency>
             <!--
               From Guice 5+ multi-bindings is officially part of the its core library.


### PR DESCRIPTION
Guice BOM comes with more dependencies declared in its BOM due to
imports in the dependencyManagement of the parent pom.

Redeclares needing whole guice for this case to only import what is
needed for apollo.